### PR TITLE
Add decorator for weighted_maximum_cut

### DIFF
--- a/dwave_networkx/algorithms/max_cut.py
+++ b/dwave_networkx/algorithms/max_cut.py
@@ -85,6 +85,7 @@ def maximum_cut(G, sampler=None, **sampler_args):
     return set(v for v in G if sample[v] >= 0)
 
 
+@binary_quadratic_model_sampler(1)
 def weighted_maximum_cut(G, sampler=None, **sampler_args):
     """Returns an approximate weighted maximum cut.
 


### PR DESCRIPTION
For consistency with `sampler` docstring, which references use of `set_default_sampler`.