### PR TITLE
Bug fix/documentation

### DIFF
--- a/dwave_networkx/algorithms/elimination_ordering.py
+++ b/dwave_networkx/algorithms/elimination_ordering.py
@@ -462,7 +462,7 @@ def elimination_order_width(G, order):
 def treewidth_branch_and_bound(G, elimination_order=None, treewidth_upperbound=None):
     """Computes the treewidth of graph G and a corresponding perfect elimination ordering.
 
-    Alogorithm based on [GD]_.
+    Algorithm based on [GD]_.
 
     Parameters
     ----------

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -45,7 +45,8 @@ def _add_compatible_edges(G, edge_list):
             G.remove_edges_from(list(G.edges))
             G.add_edges_from(edge_list)
 
-def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_list=None, data=True, coordinates=False, check_node_list=False, check_edge_list=False):
+def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_list=None,
+                  data=True, coordinates=False, check_node_list=False, check_edge_list=False):
     """Creates a Chimera lattice of size (m, n, t).
 
     Parameters
@@ -60,18 +61,18 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
         If provided, this graph is cleared of nodes and edges and filled
         with the new graph. Usually used to set the type of the graph.
     node_list : iterable (optional, default None)
-        Iterable of nodes in the graph. If None, calculated
-        from (``m``, ``n``, ``t``). The node_list should match the requested 
-        coordinate system and topology bounds; by default values should 
-        be integer-labeled in ``range(m * n * t * 2)``. Nodes incompatible
-        with the requested topology are accepted by defaulted.
+        Iterable of nodes in the graph. If None, calculated from (``m``, ``n``, ``t``) 
+        and ``coordinates``. The nodes should be compatible with the requested 
+        coordinate system and topology bounds; by default integer-labeled
+        in :code:`range(m * n * t * 2)`. Nodes incompatible
+        with the requested topology are accepted by default.
     edge_list : iterable (optional, default None)
         Iterable of edges in the graph. If None, calculated
-        from (``m``, ``n``, ``t``) as described below. The edge_list should 
-        consist of 2-tuples of nodes that match the requested 
-        coordinate system and topology bounds. Edges incompatible
+        from (``m``, ``n``, ``t``) and ``coordinates`` as described below. 
+        Edges should be 2-tuples of nodes that match the 
+        requested coordinate system and topology bounds. Edges incompatible
         with the requested topology are accepted by default. Nodes 
-        present in the edge_list, but absent in the node_list are 
+        present in the ``edge_list``, but absent in the ``node_list`` are 
         removed.
     data : bool (optional, default True)
         If True, each node has a

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -26,6 +26,8 @@ from dwave_networkx.exceptions import DWaveNetworkXException
 
 from itertools import product
 
+from .common import _add_compatible_edges
+
 __all__ = ['chimera_graph',
            'chimera_coordinates',
            'find_chimera_indices',
@@ -34,16 +36,6 @@ __all__ = ['chimera_graph',
            'chimera_sublattice_mappings',
            ]
 
-
-def _add_compatible_edges(G, edge_list):
-    # Slow when edge_list is large, but clear (non-defaulted behaviour, so fine):
-    if edge_list is not None:
-        if not all([G.has_edge(*e) for e in edge_list]):
-            raise ValueError("edge_list contains edges incompatible with a "
-                             "fully yielded graph of the requested topology")
-        if len(edge_list) < G.number_of_edges():
-            G.remove_edges_from(list(G.edges))
-            G.add_edges_from(edge_list)
 
 def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_list=None,
                   data=True, coordinates=False, check_node_list=False, check_edge_list=False):
@@ -84,13 +76,15 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
     check_node_list : bool (optional, default False)
         If True, the node_list elements are checked for compatibility with
         the graph topology and node labeling conventions, an error is thrown
-        if any node is incompatible. In other words, only node_lists that
-        specify subgraphs of the default (full yield) graph are permitted.
+        if any node is incompatible or duplicates exist. 
+        In other words, only node_lists that specify subgraphs of the default 
+        (full yield) graph are permitted.
     check_edge_list : bool (optional, default False)
         If True, the edge_list elements are checked for compatibility with
         the graph topology and node labeling conventions, an error is thrown
-        if any edge is incompatible. In other words, only edge_lists that
-        specify subgraphs of the default (full yield) graph are permitted.
+        if any edge is incompatible or duplicates exist. 
+        In other words, only edge_lists that specify subgraphs of the default 
+        (full yield) graph are permitted.
 
     Returns
     -------
@@ -216,7 +210,7 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
         nodes = set(node_list)
         G.remove_nodes_from(set(G) - nodes)
         if check_node_list:
-            if G.number_of_nodes() != len(nodes):
+            if G.number_of_nodes() != len(node_list):
                 raise ValueError("node_list contains nodes incompatible with "
                                  "the specified topology and node-labeling "
                                  "convention.")

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -71,7 +71,7 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
         attribute is a 4-tuple Chimera index as defined below.
     coordinates : bool (optional, default :code:`False`)
         If :code:`True`, node labels are 4-tuples, equivalent to the chimera_index
-        attribute as below.  In this case, the `data` parameter controls the
+        attribute as below.  In this case, the ``data`` parameter controls the
         existence of a `linear_index attribute`, which is an int.
     check_node_list : bool (optional, default :code:`False`)
         If :code:`True`, the ``node_list`` elements are checked for compatibility with

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -54,8 +54,8 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
         with the new graph. Usually used to set the type of the graph.
     node_list : iterable (optional, default None)
         Iterable of nodes in the graph. The nodes should typically be 
-        compatible with the requested lattice shape parameters and coordinate 
-        system, incompatible nodes are accepted unless you set :code:`check_node_list=True`. 
+        compatible with the requested lattice-shape parameters and coordinate 
+        system; incompatible nodes are accepted unless you set :code:`check_node_list=True`. 
         If not specified, calculated from (``m``, ``n``, ``t``) and 
         ``coordinates`` per the topology description below; all :math:`2 t m n`
         nodes are included.

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -68,12 +68,11 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
         with the requested topology are accepted by default.
     edge_list : iterable (optional, default None)
         Iterable of edges in the graph. If None, calculated
-        from (``m``, ``n``, ``t``) and ``coordinates`` as described below. 
+        from the ``node_list`` as described below. 
         Edges should be 2-tuples of nodes that match the 
-        requested coordinate system and topology bounds. Edges incompatible
-        with the requested topology are accepted by default. Nodes 
-        present in the ``edge_list``, but absent in the ``node_list`` are 
-        removed.
+        requested coordinate system and topology bounds. Edges are accepted by 
+        default, provided component nodes are contained in the ``node_list``, 
+        otherwise they are ignored.
     data : bool (optional, default True)
         If True, each node has a
         `chimera_index attribute`. The attribute is a 4-tuple Chimera index

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -80,7 +80,7 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
         In other words, the ``node_list`` must specify a subgraph of the 
         full-yield graph described below.
     check_edge_list : bool (optional, default :code:`False`)
-        If :code:`True`, the edge_list elements are checked for compatibility with
+        If :code:`True`, the ``edge_list`` elements are checked for compatibility with
         the graph topology and node labeling conventions, an error is thrown
         if any edge is incompatible or duplicates exist. 
         In other words, the ``edge_list`` must specify a subgraph of the 

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -72,7 +72,7 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
     coordinates : bool (optional, default :code:`False`)
         If :code:`True`, node labels are 4-tuples, equivalent to the chimera_index
         attribute as below.  In this case, the ``data`` parameter controls the
-        existence of a `linear_index attribute`, which is an int.
+        existence of a `linear_index attribute`, which is an integer.
     check_node_list : bool (optional, default :code:`False`)
         If :code:`True`, the ``node_list`` elements are checked for compatibility with
         the graph topology and node labeling conventions, and an error is thrown

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -53,38 +53,38 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
         If provided, this graph is cleared of nodes and edges and filled
         with the new graph. Usually used to set the type of the graph.
     node_list : iterable (optional, default None)
-        Iterable of nodes in the graph. If None, calculated from (``m``, ``n``, ``t``) 
-        and ``coordinates``. The nodes should be compatible with the requested 
-        coordinate system and topology bounds; by default integer-labeled
-        in :code:`range(m * n * t * 2)`. Nodes incompatible
-        with the requested topology are accepted by default.
+        Iterable of nodes in the graph. The nodes should typically be 
+        compatible with the requested lattice shape parameters and coordinate 
+        system, incompatible nodes are accepted unless you set :code:`check_node_list=True`. 
+        If not specified, calculated from (``m``, ``n``, ``t``) and 
+        ``coordinates`` per the topology description below; all :math:`2 t m n`
+        nodes are included.
     edge_list : iterable (optional, default None)
-        Iterable of edges in the graph. If None, calculated
-        from the ``node_list`` as described below. 
-        Edges should be 2-tuples of nodes that match the 
-        requested coordinate system and topology bounds. Edges are accepted by 
-        default, provided component nodes are contained in the ``node_list``, 
-        otherwise they are ignored.
-    data : bool (optional, default True)
-        If True, each node has a
-        `chimera_index attribute`. The attribute is a 4-tuple Chimera index
-        as defined below.
-    coordinates : bool (optional, default False)
-        If True, node labels are 4-tuples, equivalent to the chimera_index
+        Iterable of edges in the graph. Edges must be 2-tuples of the nodes 
+        specified in node_list, or calculated from (``m``, ``n``, ``t``) and 
+        ``coordinates`` per the topology description below; incompatible edges 
+        are ignored unless you set :code:`check_edge_list=True`. If not 
+        specified, all edges compatible with the ``node_list`` and topology 
+        description are included.
+    data : bool (optional, default :code:`True`)
+        If :code:`True`, each node has a `chimera_index attribute`. The 
+        attribute is a 4-tuple Chimera index as defined below.
+    coordinates : bool (optional, default :code:`False`)
+        If :code:`True`, node labels are 4-tuples, equivalent to the chimera_index
         attribute as below.  In this case, the `data` parameter controls the
         existence of a `linear_index attribute`, which is an int.
-    check_node_list : bool (optional, default False)
-        If True, the node_list elements are checked for compatibility with
-        the graph topology and node labeling conventions, an error is thrown
+    check_node_list : bool (optional, default :code:`False`)
+        If :code:`True`, the ``node_list`` elements are checked for compatibility with
+        the graph topology and node labeling conventions, and an error is thrown
         if any node is incompatible or duplicates exist. 
-        In other words, only node_lists that specify subgraphs of the default 
-        (full yield) graph are permitted.
-    check_edge_list : bool (optional, default False)
-        If True, the edge_list elements are checked for compatibility with
+        In other words, the ``node_list`` must specify a subgraph of the 
+        full-yield graph described below.
+    check_edge_list : bool (optional, default :code:`False`)
+        If :code:`True`, the edge_list elements are checked for compatibility with
         the graph topology and node labeling conventions, an error is thrown
         if any edge is incompatible or duplicates exist. 
-        In other words, only edge_lists that specify subgraphs of the default 
-        (full yield) graph are permitted.
+        In other words, the ``edge_list`` must specify a subgraph of the 
+        full-yield graph described below.
 
     Returns
     -------

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -61,7 +61,7 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
         nodes are included.
     edge_list : iterable (optional, default None)
         Iterable of edges in the graph. Edges must be 2-tuples of the nodes 
-        specified in node_list, or calculated from (``m``, ``n``, ``t``) and 
+        specified in ``node_list``, or calculated from (``m``, ``n``, ``t``) and 
         ``coordinates`` per the topology description below; incompatible edges 
         are ignored unless you set :code:`check_edge_list=True`. If not 
         specified, all edges compatible with the ``node_list`` and topology 

--- a/dwave_networkx/generators/common.py
+++ b/dwave_networkx/generators/common.py
@@ -1,0 +1,13 @@
+
+def _add_compatible_edges(G, edge_list):
+    # Check edge_list defines a subgraph of G and create subgraph.
+    # Slow when edge_list is large, but clear (non-defaulted behaviour, so fine):
+    if edge_list is not None:
+        if not all(G.has_edge(*e) for e in edge_list):
+            raise ValueError("edge_list contains edges incompatible with a "
+                             "fully yielded graph of the requested topology")
+        # Hard to check edge_list consistency owing to directedness, etc. Brute force
+        G.remove_edges_from(list(G.edges))
+        G.add_edges_from(edge_list)
+        if G.number_of_edges() < len(edge_list):
+            raise ValueError('edge_list contains duplicates.')

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -56,19 +56,18 @@ def pegasus_graph(m, create_using=None, node_list=None, edge_list=None, data=Tru
         with the new graph. Usually used to set the type of the graph.
     node_list : iterable (optional, default None)
         Iterable of nodes in the graph. If None, calculated
-        from ``m``,``fabric_only``, ``nice_coordinates`` and
+        from ``m``, ``fabric_only``, ``nice_coordinates`` and
         ``coordinates`` as described below. The nodes should be compatible
         with the requested coordinate system and topology bounds; by
         default integer-labeled in :code:`range(m * (m-1) * 24)`. Nodes
         incompatible with the requested topology are accepted by default.
     edge_list : iterable (optional, default None)
-        Iterable of edges in the graph. If None, calculated from ``m``,
-        ``fabric_only``, ``nice_coordinates`` and ``coordinates`` as described below.
+        Iterable of edges in the graph. If None, calculated from the 
+        ``node_list`` as described below.
         Edges should be 2-tuples of nodes that match the
-        requested coordinate system and topology bounds. Edges incompatible
-        with the requested topology are accepted by default. Nodes
-        present in the ``edge_list``, but absent in the ``node_list`` are
-        removed.
+        requested coordinate system and topology bounds. Edges are accepted by 
+        default, provided component nodes are contained in the ``node_list``, 
+        otherwise they are ignored.
     data : bool, optional (default True)
         If True, each node has a pegasus_index attribute. The attribute
         is a 4-tuple Pegasus index as defined below. If the `coordinates` parameter

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -45,26 +45,27 @@ def pegasus_graph(m, create_using=None, node_list=None, edge_list=None, data=Tru
         If provided, this graph is cleared of nodes and edges and filled
         with the new graph. Usually used to set the type of the graph.
     node_list : iterable (optional, default None)
-        Iterable of nodes in the graph. If None, calculated
-        from ``m``, ``fabric_only``, ``nice_coordinates`` and
-        ``coordinates`` as described below. The nodes should be compatible
-        with the requested coordinate system and topology bounds; by
-        default integer-labeled in :code:`range(m * (m-1) * 24)`. Nodes
-        incompatible with the requested topology are accepted by default.
+        Iterable of nodes in the graph.  The nodes should typically be 
+        compatible with the requested lattice shape parameters and coordinate 
+        system, incompatible nodes are accepted unless you set :code:`check_node_list=True`. 
+        If not specified, calculated from ``m``, ``fabric_only``, 
+        ``nice_coordinates``, ``offset_lists`` and ``offset_index`` and
+        ``coordinates`` per the topology description below.
     edge_list : iterable (optional, default None)
-        Iterable of edges in the graph. If None, calculated from the 
-        ``node_list`` as described below.
-        Edges should be 2-tuples of nodes that match the
-        requested coordinate system and topology bounds. Edges are accepted by 
-        default, provided component nodes are contained in the ``node_list``, 
-        otherwise they are ignored.
-    data : bool, optional (default True)
-        If True, each node has a pegasus_index attribute. The attribute
-        is a 4-tuple Pegasus index as defined below. If the `coordinates` parameter
-        is True, a linear_index, which is an integer, is used.
-    coordinates : bool, optional (default False)
-        If True, node labels are 4-tuple Pegasus indices. Ignored if the
-        `nice_coordinates` parameter is True.
+        Iterable of edges in the graph. Edges must be 2-tuples of the nodes 
+        specified in ``node_list``, or calculated from ``m``, ``fabric_only``, 
+        ``nice_coordinates``, ``offset_lists`` and ``offset_index`` and
+        ``coordinates`` per the topology description below; incompatible edges 
+        are ignored unless you set :code:`check_edge_list=True`. If not 
+        specified, all edges compatible with the ``node_list`` and topology 
+        description are included.
+    data : bool, optional (default :code:`True`)
+        If :code:`True`, each node has a pegasus_index attribute. The attribute
+        is a 4-tuple Pegasus index as defined below. If the `coordinates` 
+        parameter is :code:`True`, a linear_index, which is an integer, is used.
+    coordinates : bool, optional (default :code:`False`)
+        If :code:`True`, node labels are 4-tuple Pegasus indices. Ignored if the
+        `nice_coordinates` parameter is :code:`True`.
     offset_lists : pair of lists, optional (default None)
         Directly controls the offsets. Each list in the pair must have length 12
         and contain even ints.  If `offset_lists` is not None, the `offsets_index`
@@ -74,13 +75,13 @@ def pegasus_graph(m, create_using=None, node_list=None, edge_list=None, data=Tru
         set of topological parameters. If both the `offsets_index` and
         `offset_lists` parameters are None, the `offsets_index` parameters is set
         to zero. At least one of these two parameters must be None.
-    fabric_only: bool, optional (default True)
+    fabric_only: bool, optional (default :code:`True`)
         The Pegasus graph, by definition, has some disconnected
-        components.  If True, the generator only constructs nodes from the
-        largest component. If False, the full disconnected graph is
+        components.  If :code:`True`, the generator only constructs nodes from the
+        largest component. If :code:`False`, the full disconnected graph is
         constructed. Ignored if the `edge_lists` parameter is not None or
-        `nice_coordinates` is True
-    nice_coordinates: bool, optional (default False)
+        `nice_coordinates` is :code:`True`
+    nice_coordinates: bool, optional (default :code:`False`)
         If the `offsets_index` parameter is 0, the graph uses a "nicer"
         coordinate system, more compatible with Chimera addressing.
         These coordinates are 5-tuples taking the form :math:`(t, y, x, u, k)` where
@@ -89,14 +90,14 @@ def pegasus_graph(m, create_using=None, node_list=None, edge_list=None, data=Tru
         For any given :math:`0 <= t0 < 3`, the subgraph of nodes with :math:`t = t0`
         has the structure of `chimera(M-1, M-1, 4)` with the addition of odd couplers.
         Supercedes both the `fabric_only` and `coordinates` parameters.
-    check_node_list : bool (optional, default False)
-        If True, the node_list elements are checked for compatibility with
+    check_node_list : bool (optional, default :code:`False`)
+        If :code:`True`, the ``node_list`` elements are checked for compatibility with
         the graph topology and node labeling conventions, an error is thrown
         if any node is incompatible or duplicates exist. 
         In other words, only node_lists that specify subgraphs of the default 
         (full yield) graph are permitted.
-    check_edge_list : bool (optional, default False)
-        If True, the edge_list elements are checked for compatibility with
+    check_edge_list : bool (optional, default :code:`False`)
+        If :code:`True`, the edge_list elements are checked for compatibility with
         the graph topology and node labeling conventions, an error is thrown
         if any edge is incompatible or duplicates exist. 
         In other words, only edge_lists that specify subgraphs of the default 
@@ -111,17 +112,17 @@ def pegasus_graph(m, create_using=None, node_list=None, edge_list=None, data=Tru
     The maximum degree of this graph is 15. The number of nodes depends on multiple
     parameters; for example,
 
-        * `pegasus_graph(1)`: zero nodes
-        * `pegasus_graph(m, fabric_only=False)`: :math:`24m(m-1)` nodes
-        * `pegasus_graph(m, fabric_only=True)`: :math:`24m(m-1)-8(m-1)` nodes
-        * `pegasus_graph(m, nice_coordinates=True)`: :math:`24(m-1)^2` nodes
+        * :code:`pegasus_graph(1)`: zero nodes
+        * :code:`pegasus_graph(m, fabric_only=False)`: :math:`24m(m-1)` nodes
+        * :code:`pegasus_graph(m, fabric_only=True)`: :math:`24m(m-1)-8(m-1)` nodes
+        * :code:`pegasus_graph(m, nice_coordinates=True)`: :math:`24(m-1)^2` nodes
 
     Counting formulas for edges have a complicated dependency on parameter settings.
     Some example upper bounds are:
 
-        * `pegasus_graph(1, fabric_only=False)`: zero edges
-        * `pegasus_graph(m, fabric_only=False)`: :math:`12*(15*(m-1)^2 + m - 3)`
-          edges if m > 1
+        * :code:`pegasus_graph(1, fabric_only=False)`: zero edges
+        * :code:`pegasus_graph(m, fabric_only=False)`: :math:`12*(15*(m-1)^2 + m - 3)`
+          edges if :math:`m > 1`
 
     Note that the formulas above are valid for default offset parameters.
 

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -24,22 +24,12 @@ import warnings
 
 from itertools import product
 from .chimera import _chimera_coordinates_cache
+from .common import _add_compatible_edges
 
 __all__ = ['pegasus_graph',
            'pegasus_coordinates',
            'pegasus_sublattice_mappings',
            ]
-
-
-def _add_compatible_edges(G, edge_list):
-    # Slow when edge_list is large, but clear (non-defaulted behaviour, so fine):
-    if edge_list is not None:
-        if not all([G.has_edge(*e) for e in edge_list]):
-            raise ValueError("edge_list contains edges incompatible with a "
-                             "fully yielded graph of the requested topology")
-        if len(edge_list) < G.number_of_edges():
-            G.remove_edges_from(list(G.edges))
-            G.add_edges_from(edge_list)
 
 def pegasus_graph(m, create_using=None, node_list=None, edge_list=None, data=True,
                   offset_lists=None, offsets_index=None, coordinates=False, fabric_only=True,
@@ -102,13 +92,15 @@ def pegasus_graph(m, create_using=None, node_list=None, edge_list=None, data=Tru
     check_node_list : bool (optional, default False)
         If True, the node_list elements are checked for compatibility with
         the graph topology and node labeling conventions, an error is thrown
-        if any node is incompatible. In other words, only node_lists that
-        specify subgraphs of the default (full yield) graph are permitted.
+        if any node is incompatible or duplicates exist. 
+        In other words, only node_lists that specify subgraphs of the default 
+        (full yield) graph are permitted.
     check_edge_list : bool (optional, default False)
         If True, the edge_list elements are checked for compatibility with
         the graph topology and node labeling conventions, an error is thrown
-        if any edge is incompatible. In other words, only edge_lists that
-        specify subgraphs of the default (full yield) graph are permitted.
+        if any edge is incompatible or duplicates exist. 
+        In other words, only edge_lists that specify subgraphs of the default 
+        (full yield) graph are permitted.
 
     Returns
     -------
@@ -287,10 +279,10 @@ def pegasus_graph(m, create_using=None, node_list=None, edge_list=None, data=Tru
         nodes = set(node_list)
         G.remove_nodes_from(set(G) - nodes)
         if check_node_list:
-            if G.number_of_nodes() != len(nodes):
+            if G.number_of_nodes() != len(node_list):
                 raise ValueError("node_list contains nodes incompatible with "
                                  "the specified topology and node-labeling "
-                                 "convention.")
+                                 "convention, or duplicates")
 
         else:
             G.add_nodes_from(nodes)  # for singleton nodes

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -76,7 +76,7 @@ def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
         In other words, ``node_lists`` must specify a subgraph of the default 
         (full yield) graph described below.
     check_edge_list : bool (optional, default :code:`False`)
-        If :code:`True`, the edge_list elements are checked for compatibility with
+        If :code:`True`, ``edge_list`` elements are checked for compatibility with
         the graph topology and node labeling conventions, and an error is thrown
         if any edge is incompatible or duplicates exist. 
         In other words, only edge_lists that specify subgraphs of the default 

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -25,20 +25,12 @@ from dwave_networkx.exceptions import DWaveNetworkXException
 
 from .chimera import _chimera_coordinates_cache
 
+from .common import _add_compatible_edges
+
 __all__ = ['zephyr_graph',
            'zephyr_coordinates',
            'zephyr_sublattice_mappings',
            ]
-
-def _add_compatible_edges(G, edge_list):
-    # Slow when edge_list is large, but clear (non-defaulted behaviour, so fine):
-    if edge_list is not None:
-        if not all([G.has_edge(*e) for e in edge_list]):
-            raise ValueError("edge_list contains edges incompatible with a "
-                             "fully yielded graph of the requested topology")
-        if len(edge_list) < G.number_of_edges():
-            G.remove_edges_from(list(G.edges))
-            G.add_edges_from(edge_list)
 
 def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
                  data=True, coordinates=False, check_node_list=False, check_edge_list=False):
@@ -76,6 +68,18 @@ def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
         is True.
     coordinates : bool, optional (default False)
         If True, node labels are 5-tuple Zephyr indices.
+    check_node_list : bool (optional, default False)
+        If True, the node_list elements are checked for compatibility with
+        the graph topology and node labeling conventions, an error is thrown
+        if any node is incompatible or duplicates exist. 
+        In other words, only node_lists that specify subgraphs of the default 
+        (full yield) graph are permitted.
+    check_edge_list : bool (optional, default False)
+        If True, the edge_list elements are checked for compatibility with
+        the graph topology and node labeling conventions, an error is thrown
+        if any edge is incompatible or duplicates exist. 
+        In other words, only edge_lists that specify subgraphs of the default 
+        (full yield) graph are permitted.
 
     Returns
     -------
@@ -204,10 +208,11 @@ def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
         nodes = set(node_list)
         G.remove_nodes_from(set(G) - nodes)
         if check_node_list:
-            if G.number_of_nodes() != len(nodes):
+            if G.number_of_nodes() != len(node_list):
                 raise ValueError("node_list contains nodes incompatible with "
                                  "the specified topology and node-labeling "
-                                 "convention.")
+                                 "convention, or duplicates")
+    
 
         else:
             G.add_nodes_from(nodes)  # for singleton nodes

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -73,8 +73,8 @@ def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
         If :code:`True`, the ``node_list`` elements are checked for compatibility with
         the graph topology and node labeling conventions, and an error is thrown
         if any node is incompatible or duplicates exist. 
-        In other words, only node_lists that specify subgraphs of the default 
-        (full yield) graph are permitted.
+        In other words, ``node_lists`` must specify a subgraph of the default 
+        (full yield) graph described below.
     check_edge_list : bool (optional, default :code:`False`)
         If :code:`True`, the edge_list elements are checked for compatibility with
         the graph topology and node labeling conventions, and an error is thrown

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -79,8 +79,8 @@ def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
         If :code:`True`, ``edge_list`` elements are checked for compatibility with
         the graph topology and node labeling conventions, and an error is thrown
         if any edge is incompatible or duplicates exist. 
-        In other words, only edge_lists that specify subgraphs of the default 
-        (full yield) graph are permitted.
+        In other words, ``edge_list`` must specify a subgraph of the default 
+        (full yield) graph described below.
 
     Returns
     -------

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -64,12 +64,11 @@ def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
         the requested topology are accepted by default.
     edge_list : iterable (optional, default None)
         Iterable of edges in the graph. If None, calculated
-        from (``m``, ``t``) and ``coordinates`` as described below. 
+        from the ``node_list`` as described below. 
         Edges should be 2-tuples of nodes that match the 
-        requested coordinate system and topology bounds. Edges incompatible
-        with the requested topology are accepted by default. Nodes 
-        present in the ``edge_list``, but absent in the ``node_list`` are 
-        removed.
+        requested coordinate system and topology bounds.  Edges are accepted by 
+        default, provided component nodes are contained in the ``node_list``, 
+        otherwise they are ignored.
     data : bool, optional (default True)
         If True, adds to each node an attribute with a format that depends on
         the ``coordinates`` parameter: a 5-tuple ``'zephyr_index'`` if

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -71,7 +71,7 @@ def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
         If :code:`True`, node labels are 5-tuple Zephyr indices.
     check_node_list : bool (optional, default :code:`False`)
         If :code:`True`, the ``node_list`` elements are checked for compatibility with
-        the graph topology and node labeling conventions, an error is thrown
+        the graph topology and node labeling conventions, and an error is thrown
         if any node is incompatible or duplicates exist. 
         In other words, only node_lists that specify subgraphs of the default 
         (full yield) graph are permitted.

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -77,7 +77,7 @@ def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
         (full yield) graph are permitted.
     check_edge_list : bool (optional, default :code:`False`)
         If :code:`True`, the edge_list elements are checked for compatibility with
-        the graph topology and node labeling conventions, an error is thrown
+        the graph topology and node labeling conventions, and an error is thrown
         if any edge is incompatible or duplicates exist. 
         In other words, only edge_lists that specify subgraphs of the default 
         (full yield) graph are permitted.

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -33,7 +33,8 @@ __all__ = ['zephyr_graph',
            ]
 
 def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
-                 data=True, coordinates=False, check_node_list=False, check_edge_list=False):
+                 data=True, coordinates=False, check_node_list=False,
+                 check_edge_list=False):
     """
     Creates a Zephyr graph with grid parameter ``m`` and tile parameter ``t``.
 
@@ -49,33 +50,33 @@ def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
         If provided, this graph is cleared of nodes and edges and filled
         with the new graph. Usually used to set the type of the graph.
     node_list : iterable (optional, default None)
-        Iterable of nodes in the graph. If None, calculated from (``m``, ``t``)
-        and ``coordinates``. The nodes should be compatible with the requested
-        coordinate system and topology bounds; by default integer-labeled
-        in :code:`range(4 * t * m * (2 * m + 1))`. Nodes incompatible with
-        the requested topology are accepted by default.
+        Iterable of nodes in the graph. If not specified, calculated from (``m``, ``t``)
+        and ``coordinates``. The nodes should typically be compatible with the 
+        requested lattice shape parameters and coordinate system, incompatible 
+        nodes are accepted unless you set :code:`check_node_list=True`. If not 
+        specified, all :math:`4 t m (2 m + 1)` nodes compatible with the 
+        topology description are included.
     edge_list : iterable (optional, default None)
-        Iterable of edges in the graph. If None, calculated
-        from the ``node_list`` as described below. 
-        Edges should be 2-tuples of nodes that match the 
-        requested coordinate system and topology bounds.  Edges are accepted by 
-        default, provided component nodes are contained in the ``node_list``, 
-        otherwise they are ignored.
-    data : bool, optional (default True)
-        If True, adds to each node an attribute with a format that depends on
+        Iterable of edges in the graph. Edges must be 2-tuples of the nodes 
+        specified in node_list, or calculated from (``m``, ``t``) and ``coordinates`` 
+        per the topology description below; incompatible edges are ignored 
+        unless you set :code:`check_edge_list=True`. If not specified, all edges
+        compatible with the ``node_list`` and topology description are included.
+    data : bool, optional (default :code:`True`)
+        If :code:`True`, adds to each node an attribute with a format that depends on
         the ``coordinates`` parameter: a 5-tuple ``'zephyr_index'`` if
-        ``coordinates`` is False and an integer ``'linear_index'`` if ``coordinates``
-        is True.
-    coordinates : bool, optional (default False)
-        If True, node labels are 5-tuple Zephyr indices.
-    check_node_list : bool (optional, default False)
-        If True, the node_list elements are checked for compatibility with
+        :code:`coordinates=False` and an integer ``'linear_index'`` if ``coordinates``
+        is :code:`True`.
+    coordinates : bool, optional (default :code:`False`)
+        If :code:`True`, node labels are 5-tuple Zephyr indices.
+    check_node_list : bool (optional, default :code:`False`)
+        If :code:`True`, the ``node_list`` elements are checked for compatibility with
         the graph topology and node labeling conventions, an error is thrown
         if any node is incompatible or duplicates exist. 
         In other words, only node_lists that specify subgraphs of the default 
         (full yield) graph are permitted.
-    check_edge_list : bool (optional, default False)
-        If True, the edge_list elements are checked for compatibility with
+    check_edge_list : bool (optional, default :code:`False`)
+        If :code:`True`, the edge_list elements are checked for compatibility with
         the graph topology and node labeling conventions, an error is thrown
         if any edge is incompatible or duplicates exist. 
         In other words, only edge_lists that specify subgraphs of the default 

--- a/tests/test_generator_chimera.py
+++ b/tests/test_generator_chimera.py
@@ -282,3 +282,49 @@ class TestChimeraGraph(unittest.TestCase):
                     covered.update(map(f, source))
                 self.assertEqual(covered, set(target))
 
+
+    def test_edge_list(self):
+        m=2
+        n=3
+        t=4
+        G = dnx.chimera_graph(m, n, t)
+        edge_list = list(G.edges)
+        #Valid (full) edge_list
+        G = dnx.chimera_graph(m, n, t, edge_list=edge_list,
+                              check_edge_list=True)
+
+        #Valid edge_list in coordinate system
+        edge_list = [((0,0,0,0),(0,0,1,0))]
+        G = dnx.chimera_graph(m, n, t, edge_list=edge_list,
+                              check_node_list=True, coordinates=True)
+        
+        with self.assertRaises(ValueError):
+            #Invalid edge_list (0,1) is a vertical-vertical coupler.
+            edge_list = [(0,t),(0,1)]
+            G = dnx.chimera_graph(m, n, t, edge_list=edge_list,
+                                  check_edge_list=True)
+            
+    def test_node_list(self):
+        m=4
+        n=3
+        t=2
+        G = dnx.chimera_graph(m,n,t)
+        #Valid (full) node_list
+        node_list = list(G.nodes)
+        G = dnx.chimera_graph(m, n, t, node_list=node_list,
+                              check_node_list=True)
+        #Valid node_list in coordinate system
+        node_list = [(0,0,0,0)]
+        G = dnx.chimera_graph(m, n, t, node_list=node_list,
+                              check_node_list=True, coordinates=True)
+        with self.assertRaises(ValueError):
+            #Invalid node_list
+            node_list = [0,m*n*t*2]
+            G = dnx.chimera_graph(m, n, t, node_list=node_list,
+                                  check_node_list=True)
+        with self.assertRaises(ValueError):
+            #node is valid, but not in the requested coordinate system
+            node_list = [0]
+            G = dnx.chimera_graph(m, n, t, node_list=node_list,
+                                  check_node_list=True, coordinates=True)
+    

--- a/tests/test_generator_chimera.py
+++ b/tests/test_generator_chimera.py
@@ -284,9 +284,10 @@ class TestChimeraGraph(unittest.TestCase):
 
 
     def test_node_list(self):
-        m=4
-        n=3
-        t=2
+        m = 4
+        n = 3
+        t = 2
+        N = m*n*t*2
         G = dnx.chimera_graph(m,n,t)
         #Valid (full) node_list
         node_list = list(G.nodes)
@@ -300,9 +301,15 @@ class TestChimeraGraph(unittest.TestCase):
         self.assertEqual(G.number_of_nodes(), len(node_list))
         with self.assertRaises(ValueError):
             #Invalid node_list
-            node_list = [0,m*n*t*2]
+            node_list = [0, N]
             G = dnx.chimera_graph(m, n, t, node_list=node_list,
                                   check_node_list=True)
+        with self.assertRaises(ValueError):
+            # Invalid node_list due to duplicates
+            node_list = [0, 0]
+            G = dnx.chimera_graph(m, node_list=node_list,
+                                  check_node_list=True)
+        
         with self.assertRaises(ValueError):
             #node is valid, but not in the requested coordinate system
             node_list = [0]
@@ -311,22 +318,22 @@ class TestChimeraGraph(unittest.TestCase):
     
 
     def test_edge_list(self):
-        m=2
-        n=3
-        t=4
+        m = 2
+        n = 3
+        t = 4
         G = dnx.chimera_graph(m, n, t)
         edge_list = list(G.edges)
-        #Valid (full) edge_list
+        # Valid (full) edge_list
         G = dnx.chimera_graph(m, n, t, edge_list=edge_list,
                               check_edge_list=True)
         self.assertEqual(G.number_of_edges(),len(edge_list))
-        #Valid edge_list in coordinate system
+        # Valid edge_list in coordinate system
         edge_list = [((0,0,0,0),(0,0,1,0))]
         G = dnx.chimera_graph(m, n, t, edge_list=edge_list,
                               check_edge_list=True, coordinates=True)
         self.assertEqual(G.number_of_edges(),len(edge_list))
         
-        #Valid edge, but absent from node_list, hence dropped:
+        # Valid edge, but absent from node_list, hence dropped:
         edge_list = [(0,t)]
         node_list = list(range(t))
         G = dnx.chimera_graph(m, n, t, edge_list=edge_list, node_list = node_list,
@@ -334,8 +341,13 @@ class TestChimeraGraph(unittest.TestCase):
         self.assertEqual(G.number_of_edges(),0)
         
         with self.assertRaises(ValueError):
-            #Invalid edge_list (0,1) is a vertical-vertical coupler.
+            # Invalid edge_list (0,1) is a vertical-vertical coupler.
             edge_list = [(0,t),(0,1)]
             G = dnx.chimera_graph(m, n, t, edge_list=edge_list,
                                   check_edge_list=True)
             
+        with self.assertRaises(ValueError):
+            # Edge list has duplicates
+            edge_list = [(0, t), (0, t)]
+            G = dnx.chimera_graph(m, edge_list=edge_list,
+                                  check_edge_list=True)

--- a/tests/test_generator_chimera.py
+++ b/tests/test_generator_chimera.py
@@ -283,27 +283,6 @@ class TestChimeraGraph(unittest.TestCase):
                 self.assertEqual(covered, set(target))
 
 
-    def test_edge_list(self):
-        m=2
-        n=3
-        t=4
-        G = dnx.chimera_graph(m, n, t)
-        edge_list = list(G.edges)
-        #Valid (full) edge_list
-        G = dnx.chimera_graph(m, n, t, edge_list=edge_list,
-                              check_edge_list=True)
-
-        #Valid edge_list in coordinate system
-        edge_list = [((0,0,0,0),(0,0,1,0))]
-        G = dnx.chimera_graph(m, n, t, edge_list=edge_list,
-                              check_node_list=True, coordinates=True)
-        
-        with self.assertRaises(ValueError):
-            #Invalid edge_list (0,1) is a vertical-vertical coupler.
-            edge_list = [(0,t),(0,1)]
-            G = dnx.chimera_graph(m, n, t, edge_list=edge_list,
-                                  check_edge_list=True)
-            
     def test_node_list(self):
         m=4
         n=3
@@ -313,10 +292,12 @@ class TestChimeraGraph(unittest.TestCase):
         node_list = list(G.nodes)
         G = dnx.chimera_graph(m, n, t, node_list=node_list,
                               check_node_list=True)
+        self.assertEqual(G.number_of_nodes(), len(node_list))
         #Valid node_list in coordinate system
         node_list = [(0,0,0,0)]
         G = dnx.chimera_graph(m, n, t, node_list=node_list,
                               check_node_list=True, coordinates=True)
+        self.assertEqual(G.number_of_nodes(), len(node_list))
         with self.assertRaises(ValueError):
             #Invalid node_list
             node_list = [0,m*n*t*2]
@@ -328,3 +309,33 @@ class TestChimeraGraph(unittest.TestCase):
             G = dnx.chimera_graph(m, n, t, node_list=node_list,
                                   check_node_list=True, coordinates=True)
     
+
+    def test_edge_list(self):
+        m=2
+        n=3
+        t=4
+        G = dnx.chimera_graph(m, n, t)
+        edge_list = list(G.edges)
+        #Valid (full) edge_list
+        G = dnx.chimera_graph(m, n, t, edge_list=edge_list,
+                              check_edge_list=True)
+        self.assertEqual(G.number_of_edges(),len(edge_list))
+        #Valid edge_list in coordinate system
+        edge_list = [((0,0,0,0),(0,0,1,0))]
+        G = dnx.chimera_graph(m, n, t, edge_list=edge_list,
+                              check_edge_list=True, coordinates=True)
+        self.assertEqual(G.number_of_edges(),len(edge_list))
+        
+        #Valid edge, but absent from node_list, hence dropped:
+        edge_list = [(0,t)]
+        node_list = list(range(t))
+        G = dnx.chimera_graph(m, n, t, edge_list=edge_list, node_list = node_list,
+                              check_edge_list=True)
+        self.assertEqual(G.number_of_edges(),0)
+        
+        with self.assertRaises(ValueError):
+            #Invalid edge_list (0,1) is a vertical-vertical coupler.
+            edge_list = [(0,t),(0,1)]
+            G = dnx.chimera_graph(m, n, t, edge_list=edge_list,
+                                  check_edge_list=True)
+            

--- a/tests/test_generator_pegasus.py
+++ b/tests/test_generator_pegasus.py
@@ -289,26 +289,6 @@ class TestPegasusCoordinates(unittest.TestCase):
                     covered.update(map(f, source))
                 self.assertEqual(covered, set(target))
 
-
-    def test_edge_list(self):
-        m=4
-        G = dnx.pegasus_graph(m)
-        edge_list = list(G.edges)
-        #Valid (default) edge_list
-        G = dnx.pegasus_graph(m, edge_list=edge_list,
-                              check_edge_list=True)
-
-        #Valid edge_list in coordinate system
-        edge_list = [((0,0,0,0),(0,0,1,0))]
-        G = dnx.pegasus_graph(m, edge_list=edge_list,
-                              check_node_list=True, coordinates=True)
-        
-        with self.assertRaises(ValueError):
-            #Invalid edge_list.
-            edge_list = [(0,2)] #Vertical next nearest, no edge.
-            G = dnx.pegasus_graph(m, edge_list=edge_list, fabric_only=False,
-                                  check_edge_list=True)
-            
     def test_node_list(self):
         m=4
         G = dnx.pegasus_graph(m)
@@ -316,6 +296,7 @@ class TestPegasusCoordinates(unittest.TestCase):
         node_list = list(G.nodes)
         G = dnx.pegasus_graph(m, node_list=node_list,
                               check_node_list=True)
+        self.assertEqual(G.number_of_nodes(), len(node_list))
         
         with self.assertRaises(ValueError):
             #invalid node_list on any shape m pegasus graph
@@ -339,13 +320,40 @@ class TestPegasusCoordinates(unittest.TestCase):
         node_list = [(0,0,0,0)]
         G = dnx.pegasus_graph(m, node_list=node_list, fabric_only=False,
                               check_node_list=True, coordinates=True)
+        self.assertEqual(G.number_of_nodes(), len(node_list))
         with self.assertRaises(ValueError):
             #Incompatible coordinate presentation:
             node_list = [0]
             G = dnx.pegasus_graph(m, node_list=node_list, fabric_only=False,
                                   check_node_list=True, coordinates=True)
-    
 
+    def test_edge_list(self):
+        m=4
+        G = dnx.pegasus_graph(m)
+        edge_list = list(G.edges)
+        #Valid (default) edge_list
+        G = dnx.pegasus_graph(m, edge_list=edge_list,
+                              check_edge_list=True)
+        self.assertEqual(G.number_of_edges(),len(edge_list))
+        #Valid edge_list in coordinate system
+        edge_list = [((0, 0, 2, 0), (0, 0, 2, 1))]
+        G = dnx.pegasus_graph(m, edge_list=edge_list,
+                              check_edge_list=True, coordinates=True)
+        self.assertEqual(G.number_of_edges(),len(edge_list))
+        
+        #Valid edge, but absent from node_list, hence dropped:
+        G = dnx.pegasus_graph(m, fabric_only=False)
+        edge_list = [(0,1)]
+        node_list = [0,2]
+        G = dnx.pegasus_graph(m, edge_list=edge_list, node_list = node_list,
+                              check_edge_list=True,fabric_only=False)
+        self.assertEqual(G.number_of_edges(),0)
+        
+        with self.assertRaises(ValueError):
+            #Invalid edge_list.
+            edge_list = [(0,2)] #Vertical next nearest, no edge.
+            G = dnx.pegasus_graph(m, edge_list=edge_list, fabric_only=False,
+                                  check_edge_list=True)
             
 class TestTupleFragmentation(unittest.TestCase):
 

--- a/tests/test_generator_pegasus.py
+++ b/tests/test_generator_pegasus.py
@@ -290,6 +290,63 @@ class TestPegasusCoordinates(unittest.TestCase):
                 self.assertEqual(covered, set(target))
 
 
+    def test_edge_list(self):
+        m=4
+        G = dnx.pegasus_graph(m)
+        edge_list = list(G.edges)
+        #Valid (default) edge_list
+        G = dnx.pegasus_graph(m, edge_list=edge_list,
+                              check_edge_list=True)
+
+        #Valid edge_list in coordinate system
+        edge_list = [((0,0,0,0),(0,0,1,0))]
+        G = dnx.pegasus_graph(m, edge_list=edge_list,
+                              check_node_list=True, coordinates=True)
+        
+        with self.assertRaises(ValueError):
+            #Invalid edge_list.
+            edge_list = [(0,2)] #Vertical next nearest, no edge.
+            G = dnx.pegasus_graph(m, edge_list=edge_list, fabric_only=False,
+                                  check_edge_list=True)
+            
+    def test_node_list(self):
+        m=4
+        G = dnx.pegasus_graph(m)
+        #Valid (default) node_list
+        node_list = list(G.nodes)
+        G = dnx.pegasus_graph(m, node_list=node_list,
+                              check_node_list=True)
+        
+        with self.assertRaises(ValueError):
+            #invalid node_list on any shape m pegasus graph
+            node_list = [0,m*(m-1)*24]
+            G = dnx.pegasus_graph(m, node_list=node_list, fabric_only=False,
+                                  check_node_list=True)
+    
+        
+        #Invalid node_list (fabric_only and nice only):
+        node_list = [0]
+        with self.assertRaises(ValueError):
+            G = dnx.pegasus_graph(m, node_list=node_list, fabric_only=True,
+                                  check_node_list=True)
+        with self.assertRaises(ValueError):
+            node_list = [dnx.pegasus_coordinates(m).linear_to_nice(0)]
+            G = dnx.pegasus_graph(m, node_list=node_list, nice_coordinates=True,
+                                  check_node_list=True)
+
+            
+        #Valid coordinate presentation:
+        node_list = [(0,0,0,0)]
+        G = dnx.pegasus_graph(m, node_list=node_list, fabric_only=False,
+                              check_node_list=True, coordinates=True)
+        with self.assertRaises(ValueError):
+            #Incompatible coordinate presentation:
+            node_list = [0]
+            G = dnx.pegasus_graph(m, node_list=node_list, fabric_only=False,
+                                  check_node_list=True, coordinates=True)
+    
+
+            
 class TestTupleFragmentation(unittest.TestCase):
 
     def test_empty_list(self):

--- a/tests/test_generator_pegasus.py
+++ b/tests/test_generator_pegasus.py
@@ -290,71 +290,82 @@ class TestPegasusCoordinates(unittest.TestCase):
                 self.assertEqual(covered, set(target))
 
     def test_node_list(self):
-        m=4
+        m = 4
         G = dnx.pegasus_graph(m)
-        #Valid (default) node_list
+        # Valid (default) node_list
         node_list = list(G.nodes)
         G = dnx.pegasus_graph(m, node_list=node_list,
                               check_node_list=True)
         self.assertEqual(G.number_of_nodes(), len(node_list))
         
         with self.assertRaises(ValueError):
-            #invalid node_list on any shape m pegasus graph
+            # Invalid node_list on any shape m pegasus graph
             node_list = [0,m*(m-1)*24]
             G = dnx.pegasus_graph(m, node_list=node_list, fabric_only=False,
                                   check_node_list=True)
-    
-        
-        #Invalid node_list (fabric_only and nice only):
-        node_list = [0]
         with self.assertRaises(ValueError):
+            # Invalid node_list due to duplicates
+            node_list = [0, 0]
+            G = dnx.pegasus_graph(m, node_list=node_list, fabric_only=False,
+                                  check_node_list=True)
+        
+        with self.assertRaises(ValueError):
+            # Invalid node_list (fabric_only)
+            node_list = [0]
             G = dnx.pegasus_graph(m, node_list=node_list, fabric_only=True,
                                   check_node_list=True)
         with self.assertRaises(ValueError):
+            # Invalid node_list (nice_coordinates)
             node_list = [dnx.pegasus_coordinates(m).linear_to_nice(0)]
             G = dnx.pegasus_graph(m, node_list=node_list, nice_coordinates=True,
                                   check_node_list=True)
 
             
-        #Valid coordinate presentation:
+        # Valid coordinate presentation:
         node_list = [(0,0,0,0)]
         G = dnx.pegasus_graph(m, node_list=node_list, fabric_only=False,
                               check_node_list=True, coordinates=True)
         self.assertEqual(G.number_of_nodes(), len(node_list))
         with self.assertRaises(ValueError):
-            #Incompatible coordinate presentation:
+            # Incompatible coordinate presentation:
             node_list = [0]
             G = dnx.pegasus_graph(m, node_list=node_list, fabric_only=False,
                                   check_node_list=True, coordinates=True)
 
     def test_edge_list(self):
-        m=4
+        m = 4
         G = dnx.pegasus_graph(m)
         edge_list = list(G.edges)
-        #Valid (default) edge_list
+        # Valid (default) edge_list
         G = dnx.pegasus_graph(m, edge_list=edge_list,
                               check_edge_list=True)
         self.assertEqual(G.number_of_edges(),len(edge_list))
-        #Valid edge_list in coordinate system
+        # Valid edge_list in coordinate system
         edge_list = [((0, 0, 2, 0), (0, 0, 2, 1))]
         G = dnx.pegasus_graph(m, edge_list=edge_list,
                               check_edge_list=True, coordinates=True)
-        self.assertEqual(G.number_of_edges(),len(edge_list))
+        self.assertEqual(G.number_of_edges(), len(edge_list))
         
-        #Valid edge, but absent from node_list, hence dropped:
+        # Valid edge, but absent from node_list, hence dropped:
         G = dnx.pegasus_graph(m, fabric_only=False)
         edge_list = [(0,1)]
         node_list = [0,2]
         G = dnx.pegasus_graph(m, edge_list=edge_list, node_list = node_list,
-                              check_edge_list=True,fabric_only=False)
+                              fabric_only=False, check_edge_list=True)
         self.assertEqual(G.number_of_edges(),0)
         
         with self.assertRaises(ValueError):
-            #Invalid edge_list.
+            # Invalid edge_list.
             edge_list = [(0,2)] #Vertical next nearest, no edge.
             G = dnx.pegasus_graph(m, edge_list=edge_list, fabric_only=False,
                                   check_edge_list=True)
-            
+                    
+        with self.assertRaises(ValueError):
+            # Edge list has duplicates
+            edge_list = [(0, 1), (0, 1)]
+            G = dnx.pegasus_graph(m, edge_list=edge_list, fabric_only=False,
+                                  check_edge_list=True)
+
 class TestTupleFragmentation(unittest.TestCase):
 
     def test_empty_list(self):

--- a/tests/test_generator_zephyr.py
+++ b/tests/test_generator_zephyr.py
@@ -189,26 +189,6 @@ class TestZephyrGraph(unittest.TestCase):
                 self.assertEqual(covered, set(target))
 
 
-    def test_edge_list(self):
-        m=2
-        t=4
-        G = dnx.zephyr_graph(m, t)
-        edge_list = list(G.edges)
-        #Valid (full) edge_list
-        G = dnx.zephyr_graph(m, t, edge_list=edge_list,
-                              check_edge_list=True)
-
-        #Valid edge_list in coordinate system
-        edge_list = [((0,0,0,0),(0,0,1,0))]
-        G = dnx.zephyr_graph(m, t, edge_list=edge_list,
-                              check_node_list=True, coordinates=True)
-        
-        with self.assertRaises(ValueError):
-            #Invalid edge_list (0,1) is a vertical-vertical coupler.
-            edge_list = [(0,t),(0,1)]
-            G = dnx.zephyr_graph(m, t, edge_list=edge_list,
-                                  check_edge_list=True)
-            
     def test_node_list(self):
         m=4
         t=2
@@ -217,10 +197,12 @@ class TestZephyrGraph(unittest.TestCase):
         node_list = list(G.nodes)
         G = dnx.zephyr_graph(m, t, node_list=node_list,
                               check_node_list=True)
+        self.assertEqual(G.number_of_nodes(), len(node_list))
         #Valid node_list in coordinate system
         node_list = [(0, 0, 0, 0, 0)]
         G = dnx.zephyr_graph(m, t, node_list=node_list,
                               check_node_list=True, coordinates=True)
+        self.assertEqual(G.number_of_nodes(), len(node_list))
         with self.assertRaises(ValueError):
             #Invalid node_list
             node_list = [0, 4 * t * m * (2 * m + 1)]
@@ -232,3 +214,34 @@ class TestZephyrGraph(unittest.TestCase):
             G = dnx.zephyr_graph(m, t, node_list=node_list,
                                   check_node_list=True, coordinates=True)
     
+
+    def test_edge_list(self):
+        m=2
+        t=4
+        G = dnx.zephyr_graph(m, t)
+        edge_list = list(G.edges)
+        #Valid (full) edge_list
+        G = dnx.zephyr_graph(m, t, edge_list=edge_list,
+                              check_edge_list=True)
+        self.assertEqual(G.number_of_edges(),len(edge_list))
+
+        #Valid edge_list in coordinate system
+        edge_list = [((0, 0, 0, 0, 0), (0, 0, 0, 0, 1))]
+        G = dnx.zephyr_graph(m, t, edge_list=edge_list,
+                              check_edge_list=True, coordinates=True)
+        
+        self.assertEqual(G.number_of_edges(),len(edge_list))
+
+        #Valid edge, but absent from node_list, hence dropped:
+        edge_list = [(0,1)]
+        node_list = [0,2]
+        G = dnx.zephyr_graph(m, t, edge_list=edge_list, node_list = node_list,
+                              check_edge_list=True)
+        self.assertEqual(G.number_of_edges(), 0)
+        
+        with self.assertRaises(ValueError):
+            #Invalid edge_list (0,1) is a vertical-vertical coupler.
+            edge_list = [(0, t), (0, 1)]
+            G = dnx.zephyr_graph(m, t, edge_list=edge_list,
+                                  check_edge_list=True)
+            

--- a/tests/test_generator_zephyr.py
+++ b/tests/test_generator_zephyr.py
@@ -188,3 +188,47 @@ class TestZephyrGraph(unittest.TestCase):
                     covered.update(map(f, source))
                 self.assertEqual(covered, set(target))
 
+
+    def test_edge_list(self):
+        m=2
+        t=4
+        G = dnx.zephyr_graph(m, t)
+        edge_list = list(G.edges)
+        #Valid (full) edge_list
+        G = dnx.zephyr_graph(m, t, edge_list=edge_list,
+                              check_edge_list=True)
+
+        #Valid edge_list in coordinate system
+        edge_list = [((0,0,0,0),(0,0,1,0))]
+        G = dnx.zephyr_graph(m, t, edge_list=edge_list,
+                              check_node_list=True, coordinates=True)
+        
+        with self.assertRaises(ValueError):
+            #Invalid edge_list (0,1) is a vertical-vertical coupler.
+            edge_list = [(0,t),(0,1)]
+            G = dnx.zephyr_graph(m, t, edge_list=edge_list,
+                                  check_edge_list=True)
+            
+    def test_node_list(self):
+        m=4
+        t=2
+        G = dnx.chimera_graph(m,t)
+        #Valid (full) node_list
+        node_list = list(G.nodes)
+        G = dnx.zephyr_graph(m, t, node_list=node_list,
+                              check_node_list=True)
+        #Valid node_list in coordinate system
+        node_list = [(0, 0, 0, 0, 0)]
+        G = dnx.zephyr_graph(m, t, node_list=node_list,
+                              check_node_list=True, coordinates=True)
+        with self.assertRaises(ValueError):
+            #Invalid node_list
+            node_list = [0, 4 * t * m * (2 * m + 1)]
+            G = dnx.zephyr_graph(m, t, node_list=node_list,
+                                  check_node_list=True)
+        with self.assertRaises(ValueError):
+            #node is valid, but not in the requested coordinate system
+            node_list = [0]
+            G = dnx.zephyr_graph(m, t, node_list=node_list,
+                                  check_node_list=True, coordinates=True)
+    

--- a/tests/test_generator_zephyr.py
+++ b/tests/test_generator_zephyr.py
@@ -192,24 +192,31 @@ class TestZephyrGraph(unittest.TestCase):
     def test_node_list(self):
         m=4
         t=2
+        N = 4 * t * m * (2 * m + 1)
         G = dnx.chimera_graph(m,t)
-        #Valid (full) node_list
+        # Valid (full) node_list
         node_list = list(G.nodes)
         G = dnx.zephyr_graph(m, t, node_list=node_list,
                               check_node_list=True)
         self.assertEqual(G.number_of_nodes(), len(node_list))
-        #Valid node_list in coordinate system
+        # Valid node_list in coordinate system
         node_list = [(0, 0, 0, 0, 0)]
         G = dnx.zephyr_graph(m, t, node_list=node_list,
                               check_node_list=True, coordinates=True)
         self.assertEqual(G.number_of_nodes(), len(node_list))
         with self.assertRaises(ValueError):
-            #Invalid node_list
-            node_list = [0, 4 * t * m * (2 * m + 1)]
+            # Invalid node
+            node_list = [0, N]
             G = dnx.zephyr_graph(m, t, node_list=node_list,
                                   check_node_list=True)
         with self.assertRaises(ValueError):
-            #node is valid, but not in the requested coordinate system
+            # Duplicates
+            node_list = [0, 0]
+            G = dnx.zephyr_graph(m, node_list=node_list,
+                                 check_node_list=True)
+    
+        with self.assertRaises(ValueError):
+            # Not in the requested coordinate system
             node_list = [0]
             G = dnx.zephyr_graph(m, t, node_list=node_list,
                                   check_node_list=True, coordinates=True)
@@ -218,21 +225,22 @@ class TestZephyrGraph(unittest.TestCase):
     def test_edge_list(self):
         m=2
         t=4
+        N = 4 * t * m * (2 * m + 1)
         G = dnx.zephyr_graph(m, t)
         edge_list = list(G.edges)
-        #Valid (full) edge_list
+        # Valid (full) edge_list
         G = dnx.zephyr_graph(m, t, edge_list=edge_list,
                               check_edge_list=True)
         self.assertEqual(G.number_of_edges(),len(edge_list))
 
-        #Valid edge_list in coordinate system
+        # Valid edge_list in coordinate system
         edge_list = [((0, 0, 0, 0, 0), (0, 0, 0, 0, 1))]
         G = dnx.zephyr_graph(m, t, edge_list=edge_list,
                               check_edge_list=True, coordinates=True)
         
         self.assertEqual(G.number_of_edges(),len(edge_list))
 
-        #Valid edge, but absent from node_list, hence dropped:
+        # Valid edge, but absent from node_list, hence dropped:
         edge_list = [(0,1)]
         node_list = [0,2]
         G = dnx.zephyr_graph(m, t, edge_list=edge_list, node_list = node_list,
@@ -240,8 +248,13 @@ class TestZephyrGraph(unittest.TestCase):
         self.assertEqual(G.number_of_edges(), 0)
         
         with self.assertRaises(ValueError):
-            #Invalid edge_list (0,1) is a vertical-vertical coupler.
-            edge_list = [(0, t), (0, 1)]
+            # Invalid edge_list (0,N-1).
+            edge_list = [(0, N-1), (0, 1)]
             G = dnx.zephyr_graph(m, t, edge_list=edge_list,
                                   check_edge_list=True)
-            
+        
+        with self.assertRaises(ValueError):
+            # Edge list has duplicates
+            edge_list = [(0, 1), (0, 1)]
+            G = dnx.zephyr_graph(m, t, edge_list=edge_list,
+                                  check_edge_list=True)


### PR DESCRIPTION
Tidied up inaccuracies in docstrings for edge_list and node_list in graph generators. 
Added option for strict topological compliance of edge_list and node_list in these same generators, defaulted to legacy behaviour.
Resolves this bug: https://github.com/dwavesystems/dwave-networkx/issues/222