### PR TITLE
Fix typos and styling.

### DIFF
--- a/docs/reference/drawing.rst
+++ b/docs/reference/drawing.rst
@@ -8,9 +8,6 @@ Tools to visualize topologies of D-Wave QPUs and weighted :term:`graph` problems
 
 .. currentmodule:: dwave_networkx
 
-.. note:: Some functionality requires `NumPy <https://scipy.org>`_ and/or
-     `Matplotlib <https://matplotlib.org>`_\ .
-
 Chimera Graph Functions
 -----------------------
 

--- a/docs/reference/drawing.rst
+++ b/docs/reference/drawing.rst
@@ -9,7 +9,7 @@ Tools to visualize topologies of D-Wave QPUs and weighted :term:`graph` problems
 .. currentmodule:: dwave_networkx
 
 .. note:: Some functionality requires `NumPy <https://scipy.org>`_ and/or
-	 `Matplotlib <https://matplotlib.org>`_\ .
+     `Matplotlib <https://matplotlib.org>`_\ .
 
 Chimera Graph Functions
 -----------------------
@@ -56,12 +56,12 @@ positions on a Chimera unit cell.
    >>> # matplotlib commands to add labels to graphic not shown
 
 .. figure:: ../_images/chimera_layout_0-rightside.png
-	:align: center
-	:name: chimera_layout_0-rightside
-	:scale: 60 %
-	:alt: Graph H overlaid on a Chimera unit cell.
+    :align: center
+    :name: chimera_layout_0-rightside
+    :scale: 60 %
+    :alt: Graph H overlaid on a Chimera unit cell.
 
-	Graph H (blue) overlaid on a Chimera unit cell (red nodes and black edges).
+    Graph H (blue) overlaid on a Chimera unit cell (red nodes and black edges).
 
 
 Pegasus Graph Functions
@@ -72,11 +72,11 @@ Pegasus Graph Functions
 .. autosummary::
    :toctree: generated/
 
-     draw_pegasus
-	 draw_pegasus_embedding
-     draw_pegasus_yield
-	 pegasus_layout
-	 pegasus_node_placer_2d
+   draw_pegasus
+   draw_pegasus_embedding
+   draw_pegasus_yield
+   pegasus_layout
+   pegasus_node_placer_2d
 
 Example
 ~~~~~~~
@@ -90,22 +90,22 @@ of nodes of a simple 5-node graph on a small Pegasus lattice.
    >>> import matplotlib.pyplot as plt
    >>> G = dnx.pegasus_graph(2)
    >>> H = dnx.pegasus_graph(2, node_list=[4, 40, 41, 42, 43],
-	             edge_list=[(4, 40), (4, 41), (4, 42), (4, 43)])
+                 edge_list=[(4, 40), (4, 41), (4, 42), (4, 43)])
    >>> # Show graph H on a small Pegasus lattice
    >>> plt.ion()
    >>> # Show graph H on a small Pegasus lattice
    >>> plt.ion()
    >>> dnx.draw_pegasus(G, with_labels=True, crosses=True, node_color="Yellow")
    >>> dnx.draw_pegasus(H, crosses=True, node_color='b', style='dashed',
-	         edge_color='b', width=3)
+             edge_color='b', width=3)
 
 .. figure:: ../_images/pegasus_layout_h_on_g.png
-	:align: center
-	:name: pegasus_layout_h_on_g.png
-	:scale: 60 %
-	:alt: Graph H overlaid on a Pegasus lattice size 2.
+    :align: center
+    :name: pegasus_layout_h_on_g.png
+    :scale: 60 %
+    :alt: Graph H overlaid on a Pegasus lattice size 2.
 
-	Graph H (blue) overlaid on a small Pegasus lattice(yellow nodes and black edges).
+    Graph H (blue) overlaid on a small Pegasus lattice(yellow nodes and black edges).
 
 Zephyr Graph Functions
 ----------------------
@@ -115,11 +115,11 @@ Zephyr Graph Functions
 .. autosummary::
    :toctree: generated/
 
-     draw_zephyr
-	 draw_zephyr_embedding
-	 draw_zephyr_yield
-	 zephyr_layout
-     zephyr_node_placer_2d
+   draw_zephyr
+   draw_zephyr_embedding
+   draw_zephyr_yield
+   zephyr_layout
+   zephyr_node_placer_2d
 
 Example
 ~~~~~~~
@@ -140,9 +140,9 @@ of a five-node clique on a small Zephyr graph.
    >>> dnx.draw_zephyr_embedding(G, embedding, show_labels=True)
 
 .. figure:: ../_images/zephyr_embedding_5clique.png
-	:align: center
-	:name: zephyr_embedding_5clique.png
-	:scale: 60 %
-	:alt: Five-node clique embedded in a small Zephyr graph.
+    :align: center
+    :name: zephyr_embedding_5clique.png
+    :scale: 60 %
+    :alt: Five-node clique embedded in a small Zephyr graph.
 
-	Five-node clique embedded in a small Zephyr graph.
+    Five-node clique embedded in a small Zephyr graph.

--- a/docs/reference/drawing.rst
+++ b/docs/reference/drawing.rst
@@ -61,7 +61,8 @@ positions on a Chimera unit cell.
     :scale: 60 %
     :alt: Graph H overlaid on a Chimera unit cell.
 
-    Graph H (blue) overlaid on a Chimera unit cell (red nodes and black edges).
+    Graph ``H`` (blue) overlaid on a Chimera unit cell (red nodes and black edges),
+    which is rendered in a cross layout.
 
 
 Pegasus Graph Functions
@@ -103,9 +104,10 @@ of nodes of a simple 5-node graph on a small Pegasus lattice.
     :align: center
     :name: pegasus_layout_h_on_g.png
     :scale: 60 %
-    :alt: Graph H overlaid on a Pegasus lattice size 2.
+    :alt: Graph ``H`` overlaid on a Pegasus lattice size 2.
 
-    Graph H (blue) overlaid on a small Pegasus lattice(yellow nodes and black edges).
+    Graph ``H`` (blue) overlaid on a small Pegasus lattice (yellow nodes and black edges),
+    which is rendered in a cross layout.
 
 Zephyr Graph Functions
 ----------------------

--- a/docs/reference/drawing.rst
+++ b/docs/reference/drawing.rst
@@ -4,7 +4,7 @@
 Drawing
 *******
 
-Tools to visualize topologies of D-Wave QPUs and weighted graph problems on them.
+Tools to visualize topologies of D-Wave QPUs and weighted :term:`graph` problems on them.
 
 .. currentmodule:: dwave_networkx
 
@@ -20,7 +20,10 @@ Chimera Graph Functions
    :toctree: generated/
 
    chimera_layout
+   chimera_node_placer_2d
    draw_chimera
+   draw_chimera_embedding
+   draw_chimera_yield
 
 Example
 ~~~~~~~
@@ -69,8 +72,9 @@ Pegasus Graph Functions
 .. autosummary::
    :toctree: generated/
 
-   draw_pegasus
+     draw_pegasus
 	 draw_pegasus_embedding
+     draw_pegasus_yield
 	 pegasus_layout
 	 pegasus_node_placer_2d
 
@@ -111,10 +115,11 @@ Zephyr Graph Functions
 .. autosummary::
    :toctree: generated/
 
-   draw_zephyr
+     draw_zephyr
 	 draw_zephyr_embedding
 	 draw_zephyr_yield
 	 zephyr_layout
+     zephyr_node_placer_2d
 
 Example
 ~~~~~~~

--- a/dwave_networkx/drawing/chimera_layout.py
+++ b/dwave_networkx/drawing/chimera_layout.py
@@ -28,7 +28,9 @@ __all__ = ['chimera_layout', 'draw_chimera', 'draw_chimera_embedding', 'draw_chi
 
 
 def chimera_layout(G, scale=1., center=None, dim=2):
-    """Positions the nodes of graph ``G`` in a Chimera layout with unit cells as crosses.
+    """Positions the nodes of graph ``G`` in a Chimera layout.
+
+    Unit cells are rendered in a cross layout.
 
     NumPy (https://scipy.org) is required for this function.
 
@@ -134,7 +136,7 @@ def chimera_node_placer_2d(m, n, t, scale=1., center=None, dim=2):
 
     Returns
     -------
-    xy_coords : function
+    xy_coords : Function
         Function that maps a Chimera index ``(i, j, u, k)`` in an
         ``(m, n, t)`` Chimera lattice to x- and y-coordinates.
 
@@ -190,7 +192,9 @@ def chimera_node_placer_2d(m, n, t, scale=1., center=None, dim=2):
 
 
 def draw_chimera(G, **kwargs):
-    """Draws graph ``G`` in a Chimera layout with unit cells as crosses.
+    """Draws graph ``G`` in a Chimera layout.
+
+    Unit cells are rendered in a cross layout.
 
     Parameters
     ----------
@@ -229,7 +233,7 @@ def draw_chimera(G, **kwargs):
 
 
 def draw_chimera_embedding(G, *args, **kwargs):
-    """Draws an embedding onto the chimera graph ``G``.
+    """Draws an embedding onto the Chimera graph ``G``.
 
     Parameters
     ----------
@@ -237,16 +241,16 @@ def draw_chimera_embedding(G, *args, **kwargs):
         :term:`Chimera` :term:`graph` or a :term:`subgraph` of a Chimera graph.
 
     emb : dict
-        Embedding ``emb`` for all nodes of ``G`` as a dict of chains
+        Embedding for all nodes of ``G`` as a dict of chains
         of the form ``{node: chain, ...}``. where chains are iterables
         of qubit labels. Qubits are nodes in ``G``.
 
     embedded_graph : NetworkX graph (optional, default None)
         Graph which contains all keys of the ``emb`` parameter as nodes. If specified,
-        the edges of ``G`` will be considered interactions if and only if they
-        exist between two chains of the emb parameter and if their keys are connected by
-        an edge in the ``embedded_graph`` parameter; only the couplers between
-        chains with intended couplings are displayed.
+        the edges of ``G`` are considered to be interactions if and only if they
+        exist between two chains of the ``emb`` parameter and if their keys are connected by
+        an edge in the ``embedded_graph`` parameter; only the couplers for edges of ``G``
+        that are considered to be interactions are displayed.
 
     interaction_edges : list (optional, default None)
         Interactions as a list of edges.
@@ -259,16 +263,16 @@ def draw_chimera_embedding(G, *args, **kwargs):
         Chain colors associated with each key in the ``emb`` parameter as a dict
         of the form ``{node: rgba_color, ...}``, where colors must be length-4
         tuples of floats between 0 and 1, inclusive. If None,
-        each chain will be assigned a different color.
+        each chain is assigned a different color.
 
     unused_color : tuple (optional, default (0.9,0.9,0.9,1.0))
         Color to use for graph ``G``'s nodes and edges that are not part of
         chains, and edges that are neither chain edges nor interactions.
-        If None, these nodes and edges will not be shown.
+        If None, these nodes and edges are not shown.
 
     overlapped_embedding: boolean (optional, default False)
         If True, chains in the ``emb`` parameter may overlap (contain
-        the same vertices in ``G``), and the drawing will display these overlaps as
+        the same vertices in ``G``), and the drawing displays these overlaps as
         concentric circles.
 
     kwargs : optional keywords
@@ -281,7 +285,7 @@ def draw_chimera_embedding(G, *args, **kwargs):
 
 
 def draw_chimera_yield(G, **kwargs):
-    """Draws the given graph ``G`` with highlighted faults.
+    """Draws graph ``G`` with highlighted faults.
 
     Parameters
     ----------
@@ -290,7 +294,7 @@ def draw_chimera_yield(G, **kwargs):
 
     unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
         Color to use for graph ``G``'s nodes and edges which are not faults.
-        If None, these nodes and edges will not be shown.
+        If None, these nodes and edges are not shown.
 
     fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
         Color to represent nodes that are absent from graph ``G``. Colors must be

--- a/dwave_networkx/drawing/chimera_layout.py
+++ b/dwave_networkx/drawing/chimera_layout.py
@@ -32,8 +32,6 @@ def chimera_layout(G, scale=1., center=None, dim=2):
 
     Unit cells are rendered in a cross layout.
 
-    NumPy (https://scipy.org) is required for this function.
-
     Parameters
     ----------
     G : NetworkX graph

--- a/dwave_networkx/drawing/chimera_layout.py
+++ b/dwave_networkx/drawing/chimera_layout.py
@@ -28,7 +28,7 @@ __all__ = ['chimera_layout', 'draw_chimera', 'draw_chimera_embedding', 'draw_chi
 
 
 def chimera_layout(G, scale=1., center=None, dim=2):
-    """Position the nodes of graph ``G`` in a Chimera cross topology.
+    """Positions the nodes of graph ``G`` in a Chimera layout with unit cells as crosses.
 
     NumPy (https://scipy.org) is required for this function.
 
@@ -42,14 +42,14 @@ def chimera_layout(G, scale=1., center=None, dim=2):
         a best-effort attempt is made to find the node positions.
 
     scale : float (default 1.)
-        Scale factor. If ``scale = 1``, then all positions fit within [0, 1]
+        Scale factor. If ``scale`` = 1, all positions fit within [0, 1]
         on the x-axis and [-1, 0] on the y-axis.
 
     center : None or array (default None)
         Coordinates of the top left corner.
 
     dim : int (default 2)
-        Number of dimensions. If ``dim > 2``, then all extra dimensions are
+        Number of dimensions. If ``dim`` > 2, all extra dimensions are
         set to 0.
 
     Returns
@@ -107,7 +107,7 @@ def chimera_layout(G, scale=1., center=None, dim=2):
 
 
 def chimera_node_placer_2d(m, n, t, scale=1., center=None, dim=2):
-    """Generate a function that converts Chimera indices to x- and
+    """Generates a function that converts Chimera indices to x- and
     y-coordinates for a plot.
 
     Parameters
@@ -122,14 +122,14 @@ def chimera_node_placer_2d(m, n, t, scale=1., center=None, dim=2):
         Size of the shore within each Chimera tile.
 
     scale : float (default 1.)
-        Scale factor. If ``scale = 1``, then all positions fit within [0, 1]
+        Scale factor. If ``scale`` = 1, all positions fit within [0, 1]
         on the x-axis and [-1, 0] on the y-axis.
 
     center : None or array (default None)
         Coordinates of the top left corner.
 
     dim : int (default 2)
-        Number of dimensions. If ``dim > 2``, then all extra dimensions are
+        Number of dimensions. If ``dim`` > 2, all extra dimensions are
         set to 0.
 
     Returns
@@ -190,10 +190,7 @@ def chimera_node_placer_2d(m, n, t, scale=1., center=None, dim=2):
 
 
 def draw_chimera(G, **kwargs):
-    """Draw graph ``G`` in a Chimera cross topology.
-
-    Linear and quadratic biases are visualized on the plot as specified
-    in the ``linear_biases`` and ``quadratic_biases`` parameters.
+    """Draws graph ``G`` in a Chimera layout with unit cells as crosses.
 
     Parameters
     ----------
@@ -201,18 +198,20 @@ def draw_chimera(G, **kwargs):
         :term:`Chimera` :term:`graph` or a :term:`subgraph` of a Chimera graph.
 
     linear_biases : dict (optional, default {})
-        A dict of biases associated with each node in ``G`` and of
-        the form ``{node: bias, ...}``. Each bias is numeric.
+        Linear biases for all nodes of ``G`` as a dict of
+        the form ``{node: bias, ...}``, where each bias is numeric.
+        If specified, the linear biases are visualized on the plot.
 
     quadratic_biases : dict (optional, default {})
-        A dict of biases associated with each edge in ``G`` and of
-        the form ``{edge: bias, ...}``. Each bias is numeric. Self-loop
+        Quadratic biases for all edges of ``G`` as a dict of
+        the form ``{edge: bias, ...}``, where each bias is numeric. Self-loop
         edges (i.e., :math:`i=j`) are treated as linear biases.
+        If specified, the quadratic biases are visualized on the plot.
 
     kwargs : optional keywords
        Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
        If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
-       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
        or ``edge_color`` parameters are ignored.
 
     Examples
@@ -230,11 +229,7 @@ def draw_chimera(G, **kwargs):
 
 
 def draw_chimera_embedding(G, *args, **kwargs):
-    """Draw an embedding onto the chimera graph ``G``, according to the Chimera layout.
-
-    If the ``interaction_edges`` parameter is not None, then only display the couplers in that
-    list. If the ``embedded_graph`` parameter is not None, then only display the couplers between
-    chains with intended couplings according to the ``embedded_graph`` parameter.
+    """Draws an embedding onto the chimera graph ``G``.
 
     Parameters
     ----------
@@ -242,49 +237,51 @@ def draw_chimera_embedding(G, *args, **kwargs):
         :term:`Chimera` :term:`graph` or a :term:`subgraph` of a Chimera graph.
 
     emb : dict
-        A dict of chains associated with each node in ``G`` and
-        of the form ``{node: chain, ...}``. Chains are iterables
-        of qubit labels (qubits are nodes in ``G``).
+        Embedding ``emb`` for all nodes of ``G`` as a dict of chains
+        of the form ``{node: chain, ...}``. where chains are iterables
+        of qubit labels. Qubits are nodes in ``G``.
 
     embedded_graph : NetworkX graph (optional, default None)
-        Graph which contains all keys of the ``emb`` parameter as nodes. If specified, then
+        Graph which contains all keys of the ``emb`` parameter as nodes. If specified,
         the edges of ``G`` will be considered interactions if and only if they
-        exist between two chains of the ``emb`` parameter and if their keys are connected by
-        an edge in the ``embedded_graph`` parameter.
+        exist between two chains of the emb parameter and if their keys are connected by
+        an edge in the ``embedded_graph`` parameter; only the couplers between
+        chains with intended couplings are displayed.
 
     interaction_edges : list (optional, default None)
-        List of edges which will be used as interactions.
+        Interactions as a list of edges.
+        If this parameter is specified, only the couplers in the list are displayed.
 
     show_labels: boolean (optional, default False)
-        If True, then each chain in the ``emb`` parameter is labelled with its key.
+        If True, each chain in the ``emb`` parameter is labelled with its key.
 
     chain_color : dict (optional, default None)
-        A dict of colors associated with each key in the ``emb`` parameter and
-        of the form ``{node: rgba_color, ...}``. Colors must be length-4
+        Chain colors associated with each key in the ``emb`` parameter as a dict
+        of the form ``{node: rgba_color, ...}``, where colors must be length-4
         tuples of floats between 0 and 1, inclusive. If None,
-        then each chain will be assigned a different color.
+        each chain will be assigned a different color.
 
     unused_color : tuple (optional, default (0.9,0.9,0.9,1.0))
-        Color to use for graph ``G``'s nodes that are not part of
-        chains and edges that are neither chain edges nor interactions.
-        If None, then these nodes and edges will not be shown.
+        Color to use for graph ``G``'s nodes and edges that are not part of
+        chains, and edges that are neither chain edges nor interactions.
+        If None, these nodes and edges will not be shown.
 
     overlapped_embedding: boolean (optional, default False)
-        If True, then chains in the ``emb`` parameter may overlap (contain
+        If True, chains in the ``emb`` parameter may overlap (contain
         the same vertices in ``G``), and the drawing will display these overlaps as
         concentric circles.
 
     kwargs : optional keywords
        Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
        If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
-       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
        or ``edge_color`` parameters are ignored.
     """
     draw_embedding(G, chimera_layout(G), *args, **kwargs)
 
 
 def draw_chimera_yield(G, **kwargs):
-    """Draw the given graph ``G`` with highlighted faults, according to the Chimera layout.
+    """Draws the given graph ``G`` with highlighted faults.
 
     Parameters
     ----------
@@ -293,7 +290,7 @@ def draw_chimera_yield(G, **kwargs):
 
     unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
         Color to use for graph ``G``'s nodes and edges which are not faults.
-        If None, then these nodes and edges will not be shown.
+        If None, these nodes and edges will not be shown.
 
     fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
         Color to represent nodes that are absent from graph ``G``. Colors must be
@@ -308,9 +305,9 @@ def draw_chimera_yield(G, **kwargs):
         ``'solid'``, ``'dashed'``, ``'dotted'``, ``'dashdot'``.
 
     kwargs : optional keywords
-       Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
+       Parameters in :class:`.draw_networkx`, except for the ``pos`` parameter.
        If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
-       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
        or ``edge_color`` parameters are ignored.
     """
     try:

--- a/dwave_networkx/drawing/chimera_layout.py
+++ b/dwave_networkx/drawing/chimera_layout.py
@@ -14,7 +14,7 @@
 #
 # ================================================================================================
 """
-Tools to visualize Chimera lattices and weighted graph problems on them.
+Tools to visualize :term:`Chimera` lattices and weighted :term:`graph` problems on them.
 """
 
 import networkx as nx
@@ -28,33 +28,34 @@ __all__ = ['chimera_layout', 'draw_chimera', 'draw_chimera_embedding', 'draw_chi
 
 
 def chimera_layout(G, scale=1., center=None, dim=2):
-    """Positions the nodes of graph G in a Chimera cross topology.
+    """Position the nodes of graph ``G`` in a Chimera cross topology.
 
     NumPy (https://scipy.org) is required for this function.
 
     Parameters
     ----------
     G : NetworkX graph
-        Should be a Chimera graph or a subgraph of a
-        Chimera graph. If every node in G has a `chimera_index`
-        attribute, those are used to place the nodes. Otherwise makes
-        a best-effort attempt to find positions.
+        :term:`Chimera` :term:`graph` or :term:`subgraph` of a
+        Chimera graph. If every node in ``G`` has a ``chimera_index``
+        attribute, the node position in the ``chimera_index``
+        attribute is used to place each node. Otherwise,
+        a best-effort attempt is made to find the node positions.
 
     scale : float (default 1.)
-        Scale factor. When scale = 1,  all positions fit within [0, 1]
+        Scale factor. If ``scale = 1``, then all positions fit within [0, 1]
         on the x-axis and [-1, 0] on the y-axis.
 
     center : None or array (default None)
         Coordinates of the top left corner.
 
     dim : int (default 2)
-        Number of dimensions. When dim > 2, all extra dimensions are
+        Number of dimensions. If ``dim > 2``, then all extra dimensions are
         set to 0.
 
     Returns
     -------
     pos : dict
-        A dictionary of positions keyed by node.
+        Dictionary of positions keyed by node.
 
     Examples
     --------
@@ -106,13 +107,13 @@ def chimera_layout(G, scale=1., center=None, dim=2):
 
 
 def chimera_node_placer_2d(m, n, t, scale=1., center=None, dim=2):
-    """Generates a function that converts Chimera indices to x, y
-    coordinates for a plot.
+    """Generate a function that converts Chimera indices to x- and
+    y-coordinates for a plot.
 
     Parameters
     ----------
     m : int
-        Number of rows in the Chimera lattice.
+        Number of rows in the :term:`Chimera` lattice.
 
     n : int
         Number of columns in the Chimera lattice.
@@ -121,22 +122,21 @@ def chimera_node_placer_2d(m, n, t, scale=1., center=None, dim=2):
         Size of the shore within each Chimera tile.
 
     scale : float (default 1.)
-        Scale factor. When scale = 1,  all positions fit within [0, 1]
+        Scale factor. If ``scale = 1``, then all positions fit within [0, 1]
         on the x-axis and [-1, 0] on the y-axis.
 
     center : None or array (default None)
         Coordinates of the top left corner.
 
     dim : int (default 2)
-        Number of dimensions. When dim > 2, all extra dimensions are
+        Number of dimensions. If ``dim > 2``, then all extra dimensions are
         set to 0.
 
     Returns
     -------
     xy_coords : function
-        A function that maps a Chimera index (i, j, u, k) in an
-        (m, n, t) Chimera lattice to x,y coordinates such as
-        used by a plot.
+        Function that maps a Chimera index ``(i, j, u, k)`` in an
+        ``(m, n, t)`` Chimera lattice to x- and y-coordinates.
 
     """
     import numpy as np
@@ -190,30 +190,30 @@ def chimera_node_placer_2d(m, n, t, scale=1., center=None, dim=2):
 
 
 def draw_chimera(G, **kwargs):
-    """Draws graph G in a Chimera cross topology.
+    """Draw graph ``G`` in a Chimera cross topology.
 
-    If `linear_biases` and/or `quadratic_biases` are provided, these
-    are visualized on the plot.
+    Linear and quadratic biases are visualized on the plot as specified
+    in the ``linear_biases`` and ``quadratic_biases`` parameters.
 
     Parameters
     ----------
     G : NetworkX graph
-        Should be a Chimera graph or a subgraph of a Chimera graph.
+        :term:`Chimera` :term:`graph` or a :term:`subgraph` of a Chimera graph.
 
     linear_biases : dict (optional, default {})
-        A dict of biases associated with each node in G. Should be of
-        form {node: bias, ...}. Each bias should be numeric.
+        A dict of biases associated with each node in ``G`` and of
+        the form ``{node: bias, ...}``. Each bias is numeric.
 
     quadratic_biases : dict (optional, default {})
-        A dict of biases associated with each edge in G. Should be of
-        form {edge: bias, ...}. Each bias should be numeric. Self-loop
+        A dict of biases associated with each edge in ``G`` and of
+        the form ``{edge: bias, ...}``. Each bias is numeric. Self-loop
         edges (i.e., :math:`i=j`) are treated as linear biases.
 
     kwargs : optional keywords
-       See networkx.draw_networkx() for a description of optional keywords,
-       with the exception of the `pos` parameter which is not used by this
-       function. If `linear_biases` or `quadratic_biases` are provided,
-       any provided `node_color` or `edge_color` arguments are ignored.
+       Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
+       If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
+       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       or ``edge_color`` parameters are ignored.
 
     Examples
     --------
@@ -230,87 +230,88 @@ def draw_chimera(G, **kwargs):
 
 
 def draw_chimera_embedding(G, *args, **kwargs):
-    """Draws an embedding onto the chimera graph G, according to layout.
+    """Draw an embedding onto the chimera graph ``G``, according to the Chimera layout.
 
-    If interaction_edges is not None, then only display the couplers in that
-    list.  If embedded_graph is not None, the only display the couplers between
-    chains with intended couplings according to embedded_graph.
+    If the ``interaction_edges`` parameter is not None, then only display the couplers in that
+    list. If the ``embedded_graph`` parameter is not None, then only display the couplers between
+    chains with intended couplings according to the ``embedded_graph`` parameter.
 
     Parameters
     ----------
     G : NetworkX graph
-        Should be a Chimera graph or a subgraph of a Chimera graph.
+        :term:`Chimera` :term:`graph` or a :term:`subgraph` of a Chimera graph.
 
     emb : dict
-        A dict of chains associated with each node in G.  Should be
-        of the form {node: chain, ...}.  Chains should be iterables
-        of qubit labels (qubits are nodes in G).
+        A dict of chains associated with each node in ``G`` and
+        of the form ``{node: chain, ...}``. Chains are iterables
+        of qubit labels (qubits are nodes in ``G``).
 
     embedded_graph : NetworkX graph (optional, default None)
-        A graph which contains all keys of emb as nodes.  If specified,
-        edges of G will be considered interactions if and only if they
-        exist between two chains of emb if their keys are connected by
-        an edge in embedded_graph
+        Graph which contains all keys of the ``emb`` parameter as nodes. If specified, then
+        the edges of ``G`` will be considered interactions if and only if they
+        exist between two chains of the ``emb`` parameter and if their keys are connected by
+        an edge in the ``embedded_graph`` parameter.
 
     interaction_edges : list (optional, default None)
-        A list of edges which will be used as interactions.
+        List of edges which will be used as interactions.
 
     show_labels: boolean (optional, default False)
-        If show_labels is True, then each chain in emb is labelled with its key.
+        If True, then each chain in the ``emb`` parameter is labelled with its key.
 
     chain_color : dict (optional, default None)
-        A dict of colors associated with each key in emb.  Should be
-        of the form {node: rgba_color, ...}.  Colors should be length-4
-        tuples of floats between 0 and 1 inclusive. If chain_color is None,
-        each chain will be assigned a different color.
+        A dict of colors associated with each key in the ``emb`` parameter and
+        of the form ``{node: rgba_color, ...}``. Colors must be length-4
+        tuples of floats between 0 and 1, inclusive. If None,
+        then each chain will be assigned a different color.
 
     unused_color : tuple (optional, default (0.9,0.9,0.9,1.0))
-        The color to use for nodes and edges of G which are not involved
-        in chains, and edges which are neither chain edges nor interactions.
-        If unused_color is None, these nodes and edges will not be shown at all.
+        Color to use for graph ``G``'s nodes that are not part of
+        chains and edges that are neither chain edges nor interactions.
+        If None, then these nodes and edges will not be shown.
 
     overlapped_embedding: boolean (optional, default False)
-        If overlapped_embedding is True, then chains in emb may overlap (contain
-        the same vertices in G), and the drawing will display these overlaps as
+        If True, then chains in the ``emb`` parameter may overlap (contain
+        the same vertices in ``G``), and the drawing will display these overlaps as
         concentric circles.
 
     kwargs : optional keywords
-       See networkx.draw_networkx() for a description of optional keywords,
-       with the exception of the `pos` parameter which is not used by this
-       function. If `linear_biases` or `quadratic_biases` are provided,
-       any provided `node_color` or `edge_color` arguments are ignored.
+       Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
+       If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
+       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       or ``edge_color`` parameters are ignored.
     """
     draw_embedding(G, chimera_layout(G), *args, **kwargs)
 
 
 def draw_chimera_yield(G, **kwargs):
-    """Draws the given graph G with highlighted faults, according to layout.
+    """Draw the given graph ``G`` with highlighted faults, according to the Chimera layout.
 
     Parameters
     ----------
     G : NetworkX graph
-        The graph to be parsed for faults
+        :term:`Graph` to be parsed for faults.
 
     unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
-        The color to use for nodes and edges of G which are not faults.
-        If unused_color is None, these nodes and edges will not be shown at all.
+        Color to use for graph ``G``'s nodes and edges which are not faults.
+        If None, then these nodes and edges will not be shown.
 
     fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
-        A color to represent nodes absent from the graph G. Colors should be
-        length-4 tuples of floats between 0 and 1 inclusive.
+        Color to represent nodes that are absent from graph ``G``. Colors must be
+        length-4 tuples of floats between 0 and 1, inclusive.
 
     fault_shape : string, optional (default='x')
-        The shape of the fault nodes. Specification is as matplotlib.scatter
-        marker, one of 'so^>v<dph8'.
+        Shape of the fault nodes. The shapes are the same as those specified for
+        `Matplotlib markers <https://matplotlib.org/stable/api/markers_api.html#module-matplotlib.markers>`_.
 
     fault_style : string, optional (default='dashed')
-        Edge fault line style (solid|dashed|dotted|dashdot)
+        Line style for fault edges. The line style can be any of the following values:
+        ``'solid'``, ``'dashed'``, ``'dotted'``, ``'dashdot'``.
 
     kwargs : optional keywords
-       See networkx.draw_networkx() for a description of optional keywords,
-       with the exception of the `pos` parameter which is not used by this
-       function. If `linear_biases` or `quadratic_biases` are provided,
-       any provided `node_color` or `edge_color` arguments are ignored.
+       Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
+       If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
+       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       or ``edge_color`` parameters are ignored.
     """
     try:
         assert(G.graph["family"] == "chimera")

--- a/dwave_networkx/drawing/pegasus_layout.py
+++ b/dwave_networkx/drawing/pegasus_layout.py
@@ -32,7 +32,7 @@ __all__ = ['pegasus_layout',
 
 
 def pegasus_layout(G, scale=1., center=None, dim=2, crosses=False):
-    """Position the nodes of graph ``G`` in a Pegasus topology.
+    """Positions the nodes of graph ``G`` in a Pegasus topology.
 
     `NumPy <https://scipy.org>`_ is required for this function.
 
@@ -43,20 +43,20 @@ def pegasus_layout(G, scale=1., center=None, dim=2, crosses=False):
         the :func:`dwave_networkx.pegasus_graph` function.
 
     scale : float (default 1.)
-        Scale factor. If ``scale = 1``, then all positions fit within
+        Scale factor. If ``scale`` = 1, all positions fit within
         [0, 1] on the x-axis and [-1, 0] on the y-axis.
 
     center : None or array (default None)
         Coordinates of the top left corner.
 
     dim : int (default 2)
-        Number of dimensions. If ``dim > 2``, then all extra dimensions are
+        Number of dimensions. If ``dim`` > 2, all extra dimensions are
         set to 0.
 
     crosses: boolean (optional, default False)
-        If True, then :math:`K_{4,4}` subgraphs are shown in a cross
+        If True, :math:`K_{4,4}` subgraphs are shown in a cross
         rather than an L configuration. If ``G`` is defined with
-        ``nice_coordinates=True``, then this parameter is ignored.
+        ``nice_coordinates=True``, this parameter is ignored.
 
     Returns
     -------
@@ -97,7 +97,7 @@ def pegasus_layout(G, scale=1., center=None, dim=2, crosses=False):
 
 
 def pegasus_node_placer_2d(G, scale=1., center=None, dim=2, crosses=False):
-    """Generate a function to convert Pegasus indices to plottable coordinates.
+    """Generates a function to convert Pegasus indices to plottable coordinates.
 
     Parameters
     ----------
@@ -106,18 +106,18 @@ def pegasus_node_placer_2d(G, scale=1., center=None, dim=2, crosses=False):
         the :func:`dwave_networkx.pegasus_graph` function.
 
     scale : float (default 1.)
-        Scale factor. If ``scale = 1``, then all positions fit within
+        Scale factor. If ``scale`` = 1, all positions fit within
         [0, 1] on the x-axis and [-1, 0] on the y-axis.
 
     center : None or array (default None)
         Coordinates of the top left corner.
 
     dim : int (default 2)
-        Number of dimensions. If ``dim > 2``, then all extra dimensions are
+        Number of dimensions. If ``dim`` > 2, all extra dimensions are
         set to 0.
 
     crosses: boolean (optional, default False)
-        If True, then :math:`K_{4,4}` subgraphs are shown in a cross
+        If True, :math:`K_{4,4}` subgraphs are shown in a cross
         rather than an L configuration.
 
     Returns
@@ -176,10 +176,7 @@ def pegasus_node_placer_2d(G, scale=1., center=None, dim=2, crosses=False):
 
 
 def draw_pegasus(G, crosses=False, **kwargs):
-    """Draw graph ``G`` in a Pegasus topology.
-
-    Linear and quadratic biases are visualized on the plot as specified
-    in the ``linear_biases`` and ``quadratic_biases`` parameters.
+    """Draws graph ``G`` in a Pegasus topology.
 
     Parameters
     ----------
@@ -188,23 +185,25 @@ def draw_pegasus(G, crosses=False, **kwargs):
         the :func:`dwave_networkx.pegasus_graph` function.
 
     linear_biases : dict (optional, default {})
-        Biases as a dict of the form ``{node: bias, ...}``, where keys are
+        Linear biases as a dict of the form ``{node: bias, ...}``, where keys are
         nodes in ``G`` and biases are numeric.
+        If specified, the linear biases are visualized on the plot.
 
     quadratic_biases : dict (optional, default {})
-        Biases as a dict of the form ``{edge: bias, ...}``, where keys are
+        Quadratic biases as a dict of the form ``{edge: bias, ...}``, where keys are
         edges in ``G`` and biases are numeric. Self-loop
         edges (i.e., :math:`i=j`) are treated as linear biases.
+        If specified, the quadratic biases are visualized on the plot.
 
     crosses: boolean (optional, default False)
-        If True, then :math:`K_{4,4}` subgraphs are shown in a cross
+        If True, :math:`K_{4,4}` subgraphs are shown in a cross
         rather than an L configuration. If ``G`` is defined with
-        ``nice_coordinates=True``, then this parameter is ignored.
+        ``nice_coordinates=True``, this parameter is ignored.
 
     kwargs : optional keywords
        Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
        If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
-       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
        or ``edge_color`` parameters are ignored.
 
     Examples
@@ -224,7 +223,7 @@ def draw_pegasus(G, crosses=False, **kwargs):
 
 
 def draw_pegasus_embedding(G, *args, **kwargs):
-    """Draw an embedding onto Pegasus graph ``G``.
+    """Draws an embedding onto Pegasus graph ``G``.
 
     Parameters
     ----------
@@ -239,48 +238,48 @@ def draw_pegasus_embedding(G, *args, **kwargs):
     embedded_graph : NetworkX graph (optional, default None)
         Graph that contains all keys of the ``emb`` parameter as nodes. If specified,
         edges of ``G`` are considered interactions if and only if (1) they
-        exist between two chains of the ``emb`` parameter and (2) their keys are connected
+        exist between two chains of the emb parameter and (2) their keys are connected
         by an edge in this graph. If given, only the couplers between chains
         based on this graph are displayed.
 
     interaction_edges : list (optional, default None)
-        List of edges used as interactions. If specified,
-        then only these couplers are displayed.
+        Interactions as a list of edges. If specified,
+        only these couplers are displayed.
 
     show_labels: boolean (optional, default False)
-        If True, then each chain in the ``emb`` parameter is labelled with its key.
+        If True, each chain in the ``emb`` parameter is labelled with its key.
 
     chain_color : dict (optional, default None)
         Colors as a dict of the form ``{node: rgba_color, ...}`` associated with
         each key in the ``emb`` parameter, where colors are length-4 tuples of floats
-        between 0 and 1, inclusive. If None, then each chain is assigned a
+        between 0 and 1, inclusive. If None, each chain is assigned a
         different color.
 
     unused_color : tuple (optional, default (0.9,0.9,0.9,1.0))
-        Color for graph ``G``'s nodes that are not part of chains and edges
+        Color for graph ``G``'s nodes that are not part of chains, and edges
         that are neither chain edges nor interactions. If None,
-        then these nodes and edges are not shown.
+        these nodes and edges are not shown.
 
     crosses: boolean (optional, default False)
-        If True, then :math:`K_{4,4}` subgraphs are shown in a cross
+        If True, :math:`K_{4,4}` subgraphs are shown in a cross
         rather than an L configuration. Ignored, if ``G`` is defined with
         ``nice_coordinates=True``.
 
     overlapped_embedding: boolean (optional, default False)
-        If True, then chains in the ``emb`` parameter may overlap (contain the same vertices
+        If True, chains in the ``emb`` parameter may overlap (contain the same vertices
         in ``G``), and these overlaps are displayed as concentric circles.
 
     kwargs : optional keywords
        Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
        If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
-       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
        or ``edge_color`` parameters are ignored.
     """
     crosses = kwargs.pop("crosses", False)
     draw_embedding(G, pegasus_layout(G, crosses=crosses), *args, **kwargs)
 
 def draw_pegasus_yield(G, **kwargs):
-    """Draw the given graph ``G`` with highlighted faults, according to the layout.
+    """Draws the given graph ``G`` with highlighted faults.
 
     Parameters
     ----------
@@ -289,7 +288,7 @@ def draw_pegasus_yield(G, **kwargs):
 
     unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
         Color to use for graph ``G``'s nodes and edges which are not faults.
-        If None, then these nodes and edges will not be shown.
+        If None, these nodes and edges will not be shown.
 
     fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
         Color to represent nodes absent from the graph ``G``. Colors must be
@@ -306,7 +305,7 @@ def draw_pegasus_yield(G, **kwargs):
     kwargs : optional keywords
        Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
        If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
-       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
        or ``edge_color`` parameters are ignored.
     """
     try:

--- a/dwave_networkx/drawing/pegasus_layout.py
+++ b/dwave_networkx/drawing/pegasus_layout.py
@@ -122,7 +122,7 @@ def pegasus_node_placer_2d(G, scale=1., center=None, dim=2, crosses=False):
 
     Returns
     -------
-    xy_coords : function
+    xy_coords : Function
         Function that maps a Pegasus index ``(u, w, k, z)`` in a
         Pegasus lattice to plottable x- and y-coordinates.
 
@@ -238,7 +238,7 @@ def draw_pegasus_embedding(G, *args, **kwargs):
     embedded_graph : NetworkX graph (optional, default None)
         Graph that contains all keys of the ``emb`` parameter as nodes. If specified,
         edges of ``G`` are considered interactions if and only if (1) they
-        exist between two chains of the emb parameter and (2) their keys are connected
+        exist between two chains of the ``emb`` parameter and (2) their keys are connected
         by an edge in this graph. If given, only the couplers between chains
         based on this graph are displayed.
 
@@ -279,7 +279,7 @@ def draw_pegasus_embedding(G, *args, **kwargs):
     draw_embedding(G, pegasus_layout(G, crosses=crosses), *args, **kwargs)
 
 def draw_pegasus_yield(G, **kwargs):
-    """Draws the given graph ``G`` with highlighted faults.
+    """Draws graph ``G`` with highlighted faults.
 
     Parameters
     ----------
@@ -288,7 +288,7 @@ def draw_pegasus_yield(G, **kwargs):
 
     unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
         Color to use for graph ``G``'s nodes and edges which are not faults.
-        If None, these nodes and edges will not be shown.
+        If None, these nodes and edges are not shown.
 
     fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
         Color to represent nodes absent from the graph ``G``. Colors must be

--- a/dwave_networkx/drawing/pegasus_layout.py
+++ b/dwave_networkx/drawing/pegasus_layout.py
@@ -34,8 +34,6 @@ __all__ = ['pegasus_layout',
 def pegasus_layout(G, scale=1., center=None, dim=2, crosses=False):
     """Positions the nodes of graph ``G`` in a Pegasus topology.
 
-    `NumPy <https://scipy.org>`_ is required for this function.
-
     Parameters
     ----------
     G : NetworkX graph

--- a/dwave_networkx/drawing/pegasus_layout.py
+++ b/dwave_networkx/drawing/pegasus_layout.py
@@ -13,7 +13,7 @@
 #    limitations under the License.
 
 """
-Tools to visualize Pegasus lattices and weighted graph problems on them.
+Tools to visualize :term:`Pegasus` lattices and weighted :term:`graph` problems on them.
 """
 
 import networkx as nx
@@ -32,31 +32,31 @@ __all__ = ['pegasus_layout',
 
 
 def pegasus_layout(G, scale=1., center=None, dim=2, crosses=False):
-    """Positions the nodes of graph G in a Pegasus topology.
+    """Position the nodes of graph ``G`` in a Pegasus topology.
 
     `NumPy <https://scipy.org>`_ is required for this function.
 
     Parameters
     ----------
     G : NetworkX graph
-        A Pegasus graph or a subgraph of a Pegasus graph, as produced by
+        :term:`Pegasus` :term:`graph` or a :term:`subgraph` of a Pegasus graph as produced by
         the :func:`dwave_networkx.pegasus_graph` function.
 
     scale : float (default 1.)
-        Scale factor. A setting of ``scale = 1`` fits all positions within
+        Scale factor. If ``scale = 1``, then all positions fit within
         [0, 1] on the x-axis and [-1, 0] on the y-axis.
 
     center : None or array (default None)
         Coordinates of the top left corner.
 
     dim : int (default 2)
-        Number of dimensions. When dim > 2, all extra dimensions are
+        Number of dimensions. If ``dim > 2``, then all extra dimensions are
         set to 0.
 
     crosses: boolean (optional, default False)
-        If True, :math:`K_{4,4}` subgraphs are shown in a cross
-        rather than L configuration. Ignored if G is defined with
-        ``nice_coordinates=True``.
+        If True, then :math:`K_{4,4}` subgraphs are shown in a cross
+        rather than an L configuration. If ``G`` is defined with
+        ``nice_coordinates=True``, then this parameter is ignored.
 
     Returns
     -------
@@ -97,34 +97,34 @@ def pegasus_layout(G, scale=1., center=None, dim=2, crosses=False):
 
 
 def pegasus_node_placer_2d(G, scale=1., center=None, dim=2, crosses=False):
-    """Generates a function to convert Pegasus indices to plottable coordinates.
+    """Generate a function to convert Pegasus indices to plottable coordinates.
 
     Parameters
     ----------
     G : NetworkX graph
-        A Pegasus graph or a subgraph of a Pegasus graph, as produced by
+        :term:`Pegasus` :term:`graph` or a :term:`subgraph` of a Pegasus graph as produced by
         the :func:`dwave_networkx.pegasus_graph` function.
 
     scale : float (default 1.)
-        Scale factor. A setting of ``scale = 1`` fits all positions within
+        Scale factor. If ``scale = 1``, then all positions fit within
         [0, 1] on the x-axis and [-1, 0] on the y-axis.
 
     center : None or array (default None)
         Coordinates of the top left corner.
 
     dim : int (default 2)
-        Number of dimensions. When dim > 2, all extra dimensions are
+        Number of dimensions. If ``dim > 2``, then all extra dimensions are
         set to 0.
 
     crosses: boolean (optional, default False)
-        If True, :math:`K_{4,4}` subgraphs are shown in a cross
-        rather than L configuration.
+        If True, then :math:`K_{4,4}` subgraphs are shown in a cross
+        rather than an L configuration.
 
     Returns
     -------
     xy_coords : function
-        A function that maps a Pegasus index (u, w, k, z) in a
-        Pegasus lattice to plottable x,y coordinates.
+        Function that maps a Pegasus index ``(u, w, k, z)`` in a
+        Pegasus lattice to plottable x- and y-coordinates.
 
     """
     import numpy as np
@@ -176,36 +176,36 @@ def pegasus_node_placer_2d(G, scale=1., center=None, dim=2, crosses=False):
 
 
 def draw_pegasus(G, crosses=False, **kwargs):
-    """Draws graph G in a Pegasus topology.
+    """Draw graph ``G`` in a Pegasus topology.
 
-    If ``linear_biases`` and/or ``quadratic_biases`` are provided, these
-    are visualized on the plot.
+    Linear and quadratic biases are visualized on the plot as specified
+    in the ``linear_biases`` and ``quadratic_biases`` parameters.
 
     Parameters
     ----------
     G : NetworkX graph
-        A Pegasus graph or a subgraph of a Pegasus graph, as produced by
+        :term:`Pegasus` :term:`graph` or a :term:`subgraph` of a Pegasus graph as produced by
         the :func:`dwave_networkx.pegasus_graph` function.
 
     linear_biases : dict (optional, default {})
-        Biases as a dict, of form {node: bias, ...}, where keys are
-        nodes in G and biases are numeric.
+        Biases as a dict of the form ``{node: bias, ...}``, where keys are
+        nodes in ``G`` and biases are numeric.
 
     quadratic_biases : dict (optional, default {})
-        Biases as a dict, of form {edge: bias, ...}, where keys are
-        edges in G and biases are numeric. Self-loop
+        Biases as a dict of the form ``{edge: bias, ...}``, where keys are
+        edges in ``G`` and biases are numeric. Self-loop
         edges (i.e., :math:`i=j`) are treated as linear biases.
 
     crosses: boolean (optional, default False)
-        If True, :math:`K_{4,4}` subgraphs are shown in a cross
-        rather than L configuration. Ignored if G is defined with
-        ``nice_coordinates=True``.
+        If True, then :math:`K_{4,4}` subgraphs are shown in a cross
+        rather than an L configuration. If ``G`` is defined with
+        ``nice_coordinates=True``, then this parameter is ignored.
 
     kwargs : optional keywords
-       See networkx.draw_networkx() for a description of optional keywords,
-       with the exception of the ``pos`` parameter, which is not used by this
-       function. If ``linear_biases`` or ``quadratic_biases`` are provided,
-       any provided ``node_color`` or ``edge_color`` arguments are ignored.
+       Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
+       If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
+       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       or ``edge_color`` parameters are ignored.
 
     Examples
     --------
@@ -224,89 +224,90 @@ def draw_pegasus(G, crosses=False, **kwargs):
 
 
 def draw_pegasus_embedding(G, *args, **kwargs):
-    """Draws an embedding onto Pegasus graph G.
+    """Draw an embedding onto Pegasus graph ``G``.
 
     Parameters
     ----------
     G : NetworkX graph
-        A Pegasus graph or a subgraph of a Pegasus graph, as produced by
+        :term:`Pegasus` :term:`graph` or a :term:`subgraph` of a Pegasus graph as produced by
         the :func:`dwave_networkx.pegasus_graph` function.
 
     emb : dict
-        Chains, as a dict of form {qubit: chain, ...}, where qubits are
-        nodes in G and chains are iterables of qubit labels.
+        Chains as a dict of the form ``{qubit: chain, ...}``, where qubits are
+        nodes in ``G`` and chains are iterables of qubit labels.
 
     embedded_graph : NetworkX graph (optional, default None)
-        A graph that contains all keys of ``emb`` as nodes.  If specified,
-        edges of G are considered interactions if and only if (1) they
-        exist between two chains of ``emb`` and (2) their keys are connected
-        by an edge in this graph. If given, only couplers between chains
+        Graph that contains all keys of the ``emb`` parameter as nodes. If specified,
+        edges of ``G`` are considered interactions if and only if (1) they
+        exist between two chains of the ``emb`` parameter and (2) their keys are connected
+        by an edge in this graph. If given, only the couplers between chains
         based on this graph are displayed.
 
     interaction_edges : list (optional, default None)
-        A list of edges used as interactions. If given,
-        only these couplers are displayed.
+        List of edges used as interactions. If specified,
+        then only these couplers are displayed.
 
     show_labels: boolean (optional, default False)
-        If True, each chain in ``emb`` is labelled with its key.
+        If True, then each chain in the ``emb`` parameter is labelled with its key.
 
     chain_color : dict (optional, default None)
-        Colors as a dict of form {node: rgba_color, ...} associated with
-        each key in ``emb``, where colors are length-4 tuples of floats
-        between 0 and 1 inclusive. If None, each chain is assigned a
+        Colors as a dict of the form ``{node: rgba_color, ...}`` associated with
+        each key in the ``emb`` parameter, where colors are length-4 tuples of floats
+        between 0 and 1, inclusive. If None, then each chain is assigned a
         different color.
 
     unused_color : tuple (optional, default (0.9,0.9,0.9,1.0))
-        Color for nodes of G that are not part of chains, and edges
-        that are neither chain edges nor interactions. If None, these
-        nodes and edges are not shown.
+        Color for graph ``G``'s nodes that are not part of chains and edges
+        that are neither chain edges nor interactions. If None,
+        then these nodes and edges are not shown.
 
     crosses: boolean (optional, default False)
-        If True, :math:`K_{4,4}` subgraphs are shown in a cross
-        rather than L configuration. Ignored if G is defined with
+        If True, then :math:`K_{4,4}` subgraphs are shown in a cross
+        rather than an L configuration. Ignored, if ``G`` is defined with
         ``nice_coordinates=True``.
 
     overlapped_embedding: boolean (optional, default False)
-        If True, chains in ``emb`` may overlap (contain the same vertices
-        in G), and these overlaps are displayed as concentric circles.
+        If True, then chains in the ``emb`` parameter may overlap (contain the same vertices
+        in ``G``), and these overlaps are displayed as concentric circles.
 
     kwargs : optional keywords
-       See networkx.draw_networkx() for a description of optional keywords,
-       with the exception of the ``pos`` parameter, which is not used by this
-       function. If ``linear_biases`` or ``quadratic_biases`` are provided,
-       any provided ``node_color`` or ``edge_color`` arguments are ignored.
+       Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
+       If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
+       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       or ``edge_color`` parameters are ignored.
     """
     crosses = kwargs.pop("crosses", False)
     draw_embedding(G, pegasus_layout(G, crosses=crosses), *args, **kwargs)
 
 def draw_pegasus_yield(G, **kwargs):
-    """Draws the given graph G with highlighted faults, according to layout.
+    """Draw the given graph ``G`` with highlighted faults, according to the layout.
 
     Parameters
     ----------
     G : NetworkX graph
-        Graph to be parsed for faults.
+        :term:`Graph` to be parsed for faults.
 
     unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
-        The color to use for nodes and edges of G which are not faults.
-        If unused_color is None, these nodes and edges will not be shown at all.
+        Color to use for graph ``G``'s nodes and edges which are not faults.
+        If None, then these nodes and edges will not be shown.
 
     fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
-        A color to represent nodes absent from the graph G. Colors should be
-        length-4 tuples of floats between 0 and 1 inclusive.
+        Color to represent nodes absent from the graph ``G``. Colors must be
+        length-4 tuples of floats between 0 and 1, inclusive.
 
     fault_shape : string, optional (default='x')
-        The shape of the fault nodes. Specification is as matplotlib.scatter
-        marker, one of 'so^>v<dph8'.
+        Shape of the fault nodes. The shapes are the same as those specified for
+        `Matplotlib markers <https://matplotlib.org/stable/api/markers_api.html#module-matplotlib.markers>`_.
 
     fault_style : string, optional (default='dashed')
-        Edge fault line style (solid|dashed|dotted|dashdot)
+          Line style for fault edges. The line style can be any of the following values:
+        ``'solid'``, ``'dashed'``, ``'dotted'``, ``'dashdot'``.
 
     kwargs : optional keywords
-       See networkx.draw_networkx() for a description of optional keywords,
-       with the exception of the `pos` parameter which is not used by this
-       function. If `linear_biases` or `quadratic_biases` are provided,
-       any provided `node_color` or `edge_color` arguments are ignored.
+       Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
+       If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
+       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       or ``edge_color`` parameters are ignored.
     """
     try:
         assert(G.graph["family"] == "pegasus")

--- a/dwave_networkx/drawing/zephyr_layout.py
+++ b/dwave_networkx/drawing/zephyr_layout.py
@@ -31,7 +31,7 @@ __all__ = ['zephyr_layout',
 
 
 def zephyr_layout(G, scale=1., center=None, dim=2):
-    """Position the nodes of graph ``G`` in a Zephyr topology.
+    """Positions the nodes of graph ``G`` in a Zephyr topology.
 
     `NumPy <https://scipy.org>`_ is required for this function.
 
@@ -42,14 +42,14 @@ def zephyr_layout(G, scale=1., center=None, dim=2):
         the :func:`dwave_networkx.zephyr_graph` function.
 
     scale : float (default 1.)
-        Scale factor. If ``scale = 1``, then all positions fit within
+        Scale factor. If ``scale`` = 1, all positions fit within
         [0, 1] on the x-axis and [-1, 0] on the y-axis.
 
     center : None or array (default None)
         Coordinates of the top left corner.
 
     dim : int (default 2)
-        Number of dimensions. If ``dim > 2``, then all extra dimensions are
+        Number of dimensions. If ``dim`` > 2, all extra dimensions are
         set to 0.
 
     Returns
@@ -85,7 +85,7 @@ def zephyr_layout(G, scale=1., center=None, dim=2):
 
 
 def zephyr_node_placer_2d(G, scale=1., center=None, dim=2):
-    """Generate a function to convert Zephyr indices to plottable coordinates.
+    """Generates a function to convert Zephyr indices to plottable coordinates.
 
     Parameters
     ----------
@@ -94,14 +94,14 @@ def zephyr_node_placer_2d(G, scale=1., center=None, dim=2):
         the :func:`dwave_networkx.zephyr_graph` function.
 
     scale : float (default 1.)
-        Scale factor. If ``scale = 1``, then all positions fit within
+        Scale factor. If ``scale`` = 1, all positions fit within
         [0, 1] on the x-axis and [-1, 0] on the y-axis.
 
     center : None or array (default None)
         Coordinates of the top left corner.
 
     dim : int (default 2)
-        Number of dimensions. If ``dim > 2``, then all extra dimensions are
+        Number of dimensions. If ``dim`` > 2, all extra dimensions are
         set to 0.
 
     Returns
@@ -148,10 +148,7 @@ def zephyr_node_placer_2d(G, scale=1., center=None, dim=2):
 
 
 def draw_zephyr(G, **kwargs):
-    """Draw graph ``G`` in a Zephyr topology.
-
-    Linear and quadratic biases are visualized on the plot as specified
-    in the ``linear_biases`` and ``quadratic_biases`` parameters.
+    """Draws graph ``G`` in a Zephyr topology.
 
     Parameters
     ----------
@@ -160,18 +157,20 @@ def draw_zephyr(G, **kwargs):
         the :func:`dwave_networkx.zephyr_graph` function.
 
     linear_biases : dict (optional, default {})
-        Biases as a dict of the form ``{node: bias, ...}``, where keys are
+        Linear biases as a dict of the form ``{node: bias, ...}``, where keys are
         nodes in ``G`` and biases are numeric.
+        If specified, the linear biases are visualized on the plot.
 
     quadratic_biases : dict (optional, default {})
-        Biases as a dict of the form ``{edge: bias, ...}``, where keys are
+        Quadratic biases as a dict of the form ``{edge: bias, ...}``, where keys are
         edges in ``G`` and biases are numeric. Self-loop
         edges (i.e., :math:`i=j`) are treated as linear biases.
+        If specified, the quadratic biases are visualized on the plot.
 
     kwargs : optional keywords
        Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
        If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
-       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
        or ``edge_color`` parameters are ignored.
 
     Examples
@@ -191,7 +190,7 @@ def draw_zephyr(G, **kwargs):
 
 
 def draw_zephyr_embedding(G, *args, **kwargs):
-    """Draw an embedding onto a Zephyr graph ``G``.
+    """Draws an embedding onto a Zephyr graph ``G``.
 
     Parameters
     ----------
@@ -204,44 +203,44 @@ def draw_zephyr_embedding(G, *args, **kwargs):
         nodes in ``G`` and ``chain`` is iterables of qubit labels.
 
     embedded_graph : NetworkX graph (optional, default None)
-        Graph that contains all keys of the ``emb`` parameter as nodes. If specified, then
+        Graph that contains all keys of the ``emb`` parameter as nodes. If specified,
         the edges of ``G`` are considered interactions if and only if (1) they
-        exist between two chains of the ``emb`` parameter and (2) the keys of the
+        exist between two chains of the emb parameter and (2) the keys of the
         corresponding chains are connected by an edge in the given graph.
-        If given, then only the couplers between chains based on this graph are displayed.
+        If given, only the couplers between chains based on this graph are displayed.
 
     interaction_edges : list (optional, default None)
-        List of edges used as interactions. If specified,
-        then only these couplers are displayed.
+        Interactions as a list of edges. If specified,
+        only these couplers are displayed.
 
     show_labels: boolean (optional, default False)
-        If True, then each chain in the ``emb`` parameter is labelled with its key.
+        If True, each chain in the ``emb`` parameter is labelled with its key.
 
     chain_color : dict (optional, default None)
         Colors as a dict of the form ``{node: rgba_color, ...}`` associated with
         each key in the ``emb`` parameter, where colors are length-4 tuples of floats
-        between 0 and 1, inclusive. If None, then each chain is assigned a
+        between 0 and 1, inclusive. If None, each chain is assigned a
         different color.
 
     unused_color : tuple (optional, default (0.9,0.9,0.9,1.0))
         Color for graph ``G``'s nodes that are not part of chains and edges
-        that are neither chain edges nor interactions. If None, then these
+        that are neither chain edges nor interactions. If None, these
         nodes and edges are not shown.
 
     overlapped_embedding: boolean (optional, default False)
-        If True, then chains in the ``emb`` parameter may overlap (contain the same vertices
+        If True, chains in the ``emb`` parameter may overlap (contain the same vertices
         in ``G``), and these overlaps are displayed as concentric circles.
 
     kwargs : optional keywords
        Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
        If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
-       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
        or ``edge_color`` parameters are ignored.
     """
     draw_embedding(G, zephyr_layout(G), *args, **kwargs)
 
 def draw_zephyr_yield(G, **kwargs):
-    """Draw the given graph ``G`` with highlighted faults, according to the Zephyr layout.
+    """Draws the given graph ``G`` with highlighted faults, according to the Zephyr layout.
 
     Parameters
     ----------
@@ -250,7 +249,7 @@ def draw_zephyr_yield(G, **kwargs):
 
     unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
         Color to use for nodes and edges of ``G`` which are not faults.
-        If None, then these nodes and edges will not be shown.
+        If None, these nodes and edges will not be shown.
 
     fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
         Color to represent nodes absent from the graph ``G``. Colors must be
@@ -261,13 +260,13 @@ def draw_zephyr_yield(G, **kwargs):
         `Matplotlib markers <https://matplotlib.org/stable/api/markers_api.html#module-matplotlib.markers>`_.
 
     fault_style : string, optional (default='dashed')
-          Line style for fault edges. The line style can be any of the following values:
+        Line style for fault edges. The line style can be any of the following values:
         ``'solid'``, ``'dashed'``, ``'dotted'``, ``'dashdot'``.
 
     kwargs : optional keywords
        Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
        If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
-       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
        or ``edge_color`` parameters are ignored.
     """
     try:

--- a/dwave_networkx/drawing/zephyr_layout.py
+++ b/dwave_networkx/drawing/zephyr_layout.py
@@ -13,7 +13,7 @@
 #    limitations under the License.
 
 """
-Tools to visualize Zephyr lattices and weighted graph problems on them.
+Tools to visualize :term:`Zephyr` lattices and weighted :term:`graph` problems on them.
 """
 
 import networkx as nx
@@ -31,25 +31,25 @@ __all__ = ['zephyr_layout',
 
 
 def zephyr_layout(G, scale=1., center=None, dim=2):
-    """Positions the nodes of graph G in a Zephyr topology.
+    """Position the nodes of graph ``G`` in a Zephyr topology.
 
     `NumPy <https://scipy.org>`_ is required for this function.
 
     Parameters
     ----------
     G : NetworkX graph
-        A Zephyr graph or a subgraph of a Zephyr graph, as produced by
+        :term:`Zephyr` :term:`graph` or a :term:`subgraph` of a Zephyr graph as produced by
         the :func:`dwave_networkx.zephyr_graph` function.
 
     scale : float (default 1.)
-        Scale factor. A setting of ``scale = 1`` fits all positions within
+        Scale factor. If ``scale = 1``, then all positions fit within
         [0, 1] on the x-axis and [-1, 0] on the y-axis.
 
     center : None or array (default None)
         Coordinates of the top left corner.
 
     dim : int (default 2)
-        Number of dimensions. When dim > 2, all extra dimensions are
+        Number of dimensions. If ``dim > 2``, then all extra dimensions are
         set to 0.
 
     Returns
@@ -85,30 +85,30 @@ def zephyr_layout(G, scale=1., center=None, dim=2):
 
 
 def zephyr_node_placer_2d(G, scale=1., center=None, dim=2):
-    """Generates a function to convert Zephyr indices to plottable coordinates.
+    """Generate a function to convert Zephyr indices to plottable coordinates.
 
     Parameters
     ----------
     G : NetworkX graph
-        A Zephyr graph or a subgraph of a Zephyr graph, as produced by
+        :term:`Zephyr` :term:`graph` or a :term:`subgraph` of a Zephyr graph as produced by
         the :func:`dwave_networkx.zephyr_graph` function.
 
     scale : float (default 1.)
-        Scale factor. A setting of ``scale = 1`` fits all positions within
+        Scale factor. If ``scale = 1``, then all positions fit within
         [0, 1] on the x-axis and [-1, 0] on the y-axis.
 
     center : None or array (default None)
         Coordinates of the top left corner.
 
     dim : int (default 2)
-        Number of dimensions. When dim > 2, all extra dimensions are
+        Number of dimensions. If ``dim > 2``, then all extra dimensions are
         set to 0.
 
     Returns
     -------
     xy_coords : function
-        A function that maps a Zephyr index (u, w, k, j, z) in a
-        Zephyr lattice to plottable x,y coordinates.
+        Function that maps a Zephyr index ``(u, w, k, j, z)`` in a
+        Zephyr lattice to plottable x- and y-coordinates.
 
     """
     import numpy as np
@@ -148,32 +148,31 @@ def zephyr_node_placer_2d(G, scale=1., center=None, dim=2):
 
 
 def draw_zephyr(G, **kwargs):
-    """Draws graph G in a Zephyr topology.
+    """Draw graph ``G`` in a Zephyr topology.
 
-    If ``linear_biases`` and/or ``quadratic_biases`` are provided, these
-    are visualized on the plot.
+    Linear and quadratic biases are visualized on the plot as specified
+    in the ``linear_biases`` and ``quadratic_biases`` parameters.
 
     Parameters
     ----------
     G : NetworkX graph
-        A Zephyr graph or a subgraph of a Zephyr graph, as produced by
+        :term:`Zephyr` :term:`graph` or a :term:`subgraph` of a Zephyr graph as produced by
         the :func:`dwave_networkx.zephyr_graph` function.
 
     linear_biases : dict (optional, default {})
-        Biases as a dict, of form {node: bias, ...}, where keys are
-        nodes in G and biases are numeric.
+        Biases as a dict of the form ``{node: bias, ...}``, where keys are
+        nodes in ``G`` and biases are numeric.
 
     quadratic_biases : dict (optional, default {})
-        Biases as a dict, of form {edge: bias, ...}, where keys are
-        edges in G and biases are numeric. Self-loop
+        Biases as a dict of the form ``{edge: bias, ...}``, where keys are
+        edges in ``G`` and biases are numeric. Self-loop
         edges (i.e., :math:`i=j`) are treated as linear biases.
 
     kwargs : optional keywords
-       See :func:`~networkx.drawing.nx_pylab.draw_networkx` for a description of
-       optional keywords, with the exception of the ``pos`` parameter, which is
-       unsupported. If the ``linear_biases`` or ``quadratic_biases`` parameters
-       are provided, any provided ``node_color`` or ``edge_color`` arguments are
-       ignored.
+       Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
+       If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
+       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       or ``edge_color`` parameters are ignored.
 
     Examples
     --------
@@ -192,87 +191,84 @@ def draw_zephyr(G, **kwargs):
 
 
 def draw_zephyr_embedding(G, *args, **kwargs):
-    """Draws an embedding onto Zephyr graph G.
+    """Draw an embedding onto a Zephyr graph ``G``.
 
     Parameters
     ----------
     G : NetworkX graph
-        A Zephyr graph or a subgraph of a Zephyr graph, as produced by
+        :term:`Zephyr` :term:`graph` or a :term:`subgraph` of a Zephyr graph as produced by
         the :func:`dwave_networkx.zephyr_graph` function.
 
     emb : dict
-        Minor-embedding as a dict of form {node: chain, ...}, where ``node`` are
-        nodes in G and ``chain`` are iterables of qubit labels.
+        Minor-embedding as a dict of the form ``{node: chain, ...}``, where ``node`` is
+        nodes in ``G`` and ``chain`` is iterables of qubit labels.
 
     embedded_graph : NetworkX graph (optional, default None)
-        A graph that contains all keys of ``emb`` as nodes.  If specified,
-        edges of G are considered interactions if and only if (1) they
-        exist between two chains of ``emb`` and (2) the keys of the
-        corresponding chains are connected by an edge in  the given graph.
-        If given, only couplers between chains based on this graph are displayed.
+        Graph that contains all keys of the ``emb`` parameter as nodes. If specified, then
+        the edges of ``G`` are considered interactions if and only if (1) they
+        exist between two chains of the ``emb`` parameter and (2) the keys of the
+        corresponding chains are connected by an edge in the given graph.
+        If given, then only the couplers between chains based on this graph are displayed.
 
     interaction_edges : list (optional, default None)
-        A list of edges used as interactions. If given,
-        only these couplers are displayed.
+        List of edges used as interactions. If specified,
+        then only these couplers are displayed.
 
     show_labels: boolean (optional, default False)
-        If True, each chain in ``emb`` is labelled with its key.
+        If True, then each chain in the ``emb`` parameter is labelled with its key.
 
     chain_color : dict (optional, default None)
-        Colors as a dict of form {node: rgba_color, ...} associated with
-        each key in ``emb``, where colors are length-4 tuples of floats
-        between 0 and 1 inclusive. If None, each chain is assigned a
+        Colors as a dict of the form ``{node: rgba_color, ...}`` associated with
+        each key in the ``emb`` parameter, where colors are length-4 tuples of floats
+        between 0 and 1, inclusive. If None, then each chain is assigned a
         different color.
 
     unused_color : tuple (optional, default (0.9,0.9,0.9,1.0))
-        Color for nodes of G that are not part of chains, and edges
-        that are neither chain edges nor interactions. If None, these
+        Color for graph ``G``'s nodes that are not part of chains and edges
+        that are neither chain edges nor interactions. If None, then these
         nodes and edges are not shown.
 
     overlapped_embedding: boolean (optional, default False)
-        If True, chains in ``emb`` may overlap (contain the same vertices
-        in G), and these overlaps are displayed as concentric circles.
+        If True, then chains in the ``emb`` parameter may overlap (contain the same vertices
+        in ``G``), and these overlaps are displayed as concentric circles.
 
     kwargs : optional keywords
-       See :func:`~networkx.drawing.nx_pylab.draw_networkx` for a description of
-       optional keywords, with the exception of the ``pos`` parameter, which is
-       unsupported. If the ``linear_biases`` or ``quadratic_biases`` parameters
-       are provided, any provided ``node_color`` or ``edge_color`` arguments are
-       ignored.
+       Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
+       If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
+       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       or ``edge_color`` parameters are ignored.
     """
     draw_embedding(G, zephyr_layout(G), *args, **kwargs)
 
 def draw_zephyr_yield(G, **kwargs):
-    """Draws the given graph G with highlighted faults, according to layout.
+    """Draw the given graph ``G`` with highlighted faults, according to the Zephyr layout.
 
     Parameters
     ----------
     G : NetworkX graph
-        Graph to be parsed for faults.
+        :term:`Graph` to be parsed for faults.
 
     unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
-        The color to use for nodes and edges of G which are not faults.
-        If unused_color is None, these nodes and edges will not be shown at all.
+        Color to use for nodes and edges of ``G`` which are not faults.
+        If None, then these nodes and edges will not be shown.
 
     fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
-        A color to represent nodes absent from the graph G. Colors should be
-        length-4 tuples of floats between 0 and 1 inclusive.
+        Color to represent nodes absent from the graph ``G``. Colors must be
+        length-4 tuples of floats between 0 and 1, inclusive.
 
     fault_shape : string, optional (default='x')
-        The shape of the fault nodes. Specification is as for
-        `Matplotlib's markers <https://matplotlib.org/stable/api/markers_api.html#module-matplotlib.markers>`_;
-        for example "o" (circle), "^" (triangle)", "s" (square) and many more
-        options.
+        Shape of the fault nodes. The shapes are the same as those specified for
+        `Matplotlib markers <https://matplotlib.org/stable/api/markers_api.html#module-matplotlib.markers>`_.
 
     fault_style : string, optional (default='dashed')
-        Edge fault line style (solid|dashed|dotted|dashdot)
+          Line style for fault edges. The line style can be any of the following values:
+        ``'solid'``, ``'dashed'``, ``'dotted'``, ``'dashdot'``.
 
     kwargs : optional keywords
-       See :func:`~networkx.drawing.nx_pylab.draw_networkx` for a description of
-       optional keywords, with the exception of the ``pos`` parameter, which is
-       unsupported. If the ``linear_biases`` or ``quadratic_biases`` parameters
-       are provided, any provided ``node_color`` or ``edge_color`` arguments are
-       ignored.
+       Parameters in :func:`~networkx.drawing.nx_pylab.draw_networkx`, except for the ``pos`` parameter.
+       If the ``linear_biases`` or ``quadratic_biases`` parameters are specified,
+       then the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
+       or ``edge_color`` parameters are ignored.
     """
     try:
         assert(G.graph["family"] == "zephyr")

--- a/dwave_networkx/drawing/zephyr_layout.py
+++ b/dwave_networkx/drawing/zephyr_layout.py
@@ -33,8 +33,6 @@ __all__ = ['zephyr_layout',
 def zephyr_layout(G, scale=1., center=None, dim=2):
     """Positions the nodes of graph ``G`` in a Zephyr topology.
 
-    `NumPy <https://scipy.org>`_ is required for this function.
-
     Parameters
     ----------
     G : NetworkX graph

--- a/dwave_networkx/drawing/zephyr_layout.py
+++ b/dwave_networkx/drawing/zephyr_layout.py
@@ -106,7 +106,7 @@ def zephyr_node_placer_2d(G, scale=1., center=None, dim=2):
 
     Returns
     -------
-    xy_coords : function
+    xy_coords : Function
         Function that maps a Zephyr index ``(u, w, k, j, z)`` in a
         Zephyr lattice to plottable x- and y-coordinates.
 
@@ -205,7 +205,7 @@ def draw_zephyr_embedding(G, *args, **kwargs):
     embedded_graph : NetworkX graph (optional, default None)
         Graph that contains all keys of the ``emb`` parameter as nodes. If specified,
         the edges of ``G`` are considered interactions if and only if (1) they
-        exist between two chains of the emb parameter and (2) the keys of the
+        exist between two chains of the ``emb`` parameter and (2) the keys of the
         corresponding chains are connected by an edge in the given graph.
         If given, only the couplers between chains based on this graph are displayed.
 
@@ -240,7 +240,7 @@ def draw_zephyr_embedding(G, *args, **kwargs):
     draw_embedding(G, zephyr_layout(G), *args, **kwargs)
 
 def draw_zephyr_yield(G, **kwargs):
-    """Draws the given graph ``G`` with highlighted faults, according to the Zephyr layout.
+    """Draws graph ``G`` with highlighted faults, according to the Zephyr layout.
 
     Parameters
     ----------
@@ -249,7 +249,7 @@ def draw_zephyr_yield(G, **kwargs):
 
     unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
         Color to use for nodes and edges of ``G`` which are not faults.
-        If None, these nodes and edges will not be shown.
+        If None, these nodes and edges are not shown.
 
     fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
         Color to represent nodes absent from the graph ``G``. Colors must be


### PR DESCRIPTION
Copyedit for clarity.
Add reference documentation for the following methods because they were not being generated:
-    chimera_node_placer_2d
-    draw_chimera_embedding
-    draw_chimera_yield
-    draw_pegasus_yield
-    zephyr_node_placer_2d