### PR TITLE
Explicitly specify osx resource class in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
             brew install pyenv
 
       - restore_cache: &restore-cache-pyenv
-          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-13.2.0
+          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-14.3.0
 
       - run:
           name: Install python
@@ -82,7 +82,7 @@ jobs:
             pyenv install << parameters.python-version>> -s
 
       - save_cache: &save-cache-pyenv
-          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-13.2.0
+          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-14.3.0
           paths:
             - ~/.pyenv
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,8 @@ jobs:
       python-version:
         type: string
 
+    resource_class: macos.x86.medium.gen2   
+    
     macos:
       xcode: "14.3.0"
 


### PR DESCRIPTION
It's supposed to route [automatically](https://discuss.circleci.com/t/macos-resource-deprecation-update/46891), but currently we get an error
![image](https://github.com/dwavesystems/dwave-networkx/assets/8395238/9f371822-7221-4164-af23-3cdc26e00def)
so specifying it explicitly.

See https://github.com/dwavesystems/dwave-networkx/pull/230#issuecomment-1540586504