### PR TITLE
Fixed docstrings for graph relabeling and sublattice mapping functionality missing from reference documentation.

### DIFF
--- a/docs/reference/utilities.rst
+++ b/docs/reference/utilities.rst
@@ -35,21 +35,28 @@ Chimera
    :toctree: generated/
 
    chimera_coordinates.chimera_to_linear
+   chimera_coordinates.graph_to_chimera
+   chimera_coordinates.graph_to_linear
    chimera_coordinates.linear_to_chimera
+   chimera_sublattice_mappings
    find_chimera_indices
-
+   
 Pegasus
 ~~~~~~~
 
 .. autosummary::
    :toctree: generated/
 
+   pegasus_coordinates.graph_to_linear
+   pegasus_coordinates.graph_to_nice
+   pegasus_coordinates.graph_to_pegasus
    pegasus_coordinates.linear_to_nice
    pegasus_coordinates.linear_to_pegasus
    pegasus_coordinates.nice_to_linear
    pegasus_coordinates.nice_to_pegasus
    pegasus_coordinates.pegasus_to_linear
    pegasus_coordinates.pegasus_to_nice
+   pegasus_sublattice_mappings
 
 
 Zephyr

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -252,7 +252,7 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
 
 
 def find_chimera_indices(G):
-    """Attempts to determine the Chimera indices of the nodes in graph G.
+    """Attempt to determine the Chimera indices of the nodes in graph G.
 
     See the :func:`~chimera_graph()` function for a definition of a Chimera graph and Chimera
     indices.
@@ -496,7 +496,7 @@ class chimera_coordinates(object):
         return self._pair_repack(self.iter_linear_to_chimera, plist)
 
     def graph_to_linear(self, g):
-        """Return a copy of the graph g relabeled to have linear indices"""
+        """Return a copy of the graph `g` relabeled to have linear indices."""
         labels = g.graph.get('labels')
         if labels == 'int':
             return g.copy()
@@ -515,7 +515,7 @@ class chimera_coordinates(object):
             )
 
     def graph_to_chimera(self, g):
-        """Return a copy of the graph g relabeled to have chimera coordinates"""
+        """Return a copy of the graph `g` relabeled to have Chimera coordinates."""
         labels = g.graph.get('labels')
         if labels == 'int':
             return chimera_graph(
@@ -545,7 +545,7 @@ class __chimera_coordinates_cache_dict(dict):
 _chimera_coordinates_cache = __chimera_coordinates_cache_dict()
 
 def linear_to_chimera(r, m, n=None, t=None):
-    """Convert the linear index `r` into a chimera index.
+    """Convert the linear index `r` into a Chimera index.
 
     Parameters
     ----------
@@ -566,7 +566,7 @@ def linear_to_chimera(r, m, n=None, t=None):
     j : int
         The row of the Chimera index's unit cell associated with `r`.
     u : int
-        Whether the index is even (0) or odd (1); the side of the bi-partite
+        Whether the index is even (0) or odd (1); the side of the bipartite
         graph of the Chimera unit cell.
     k : int
         Index into the Chimera unit cell.
@@ -591,7 +591,7 @@ def chimera_to_linear(i, j, u, k, m, n=None, t=None):
     j : int
         The row of the Chimera index's unit cell associated with `r`.
     u : int
-        Whether the index is even (0) or odd (1); the side of the bi-partite
+        Whether the index is even (0) or odd (1); the side of the bipartite
         graph of the Chimera unit cell.
     k : int
         Index into the Chimera unit cell.
@@ -626,11 +626,11 @@ def _chimera_sublattice_mapping(source_to_chimera, chimera_to_target, offset):
     Parameters
     ----------
         source_to_chimera : function
-            A function mapping a source node to a chimera-coordinate 
+            A function mapping a source node to a chimera-coordinate. 
         chimera_to_target: function
-            A function mapping a chimera coordinate to a target nodes
+            A function mapping a chimera coordinate to a target nodes.
         offset : tuple (int, int)
-            A pair of ints representing the y- and x-offset of the sublattice
+            A pair of ints representing the y- and x-offset of the sublattice.
 
     Returns
     -------
@@ -653,53 +653,55 @@ def _chimera_sublattice_mapping(source_to_chimera, chimera_to_target, offset):
 
 
 def chimera_sublattice_mappings(source, target, offset_list=None):
-    """Yields mappings from a Chimera graph into a larger Chimera graph.
-    
-    A sublattice mapping is a function from nodes of a
-    ``chimera_graph(m_s, n_s, t)`` to nodes of a ``chimera_graph(m_t, n_t, t)``
-    with ``m_s <= m_t`` and ``n_s <= n_t``.  This is used to identify subgraphs 
-    of the target Chimera graphs which are isomorphic to the source Chimera
-    graph.  However, if the target graph is not of perfect yield, these 
-    functions do not generally produce isomorphisms (for example, if a node is
-    missing in the target graph, it may still appear in the image of the source
-    graph).
-    
-    Note that we do not produce mappings between Chimera graphs of different
-    tile parameters, and the mappings produced are not exhaustive.  The mappings
-    take the form
-    
-        ``(y, x, u, k) -> (y + y_offset, x + x_offset, u, k)``
-        
-    preserving the orientation and tile index of nodes.  We use the notation of
-    Chimera coordinates above, but either or both of the target graph may have
-    integer or coordinate labels.
-    
-    Academic note: the full group of isomorphisms of a Chimera graph includes 
-    mappings which permute tile indices on a per-row and per-column basis, in
-    addition to reflections and rotations of the grid of unit cells where 
-    rotations by 90 and 270 degrees induce a change in orientation.  The full
-    set of sublattice mappings would take those isomorphisms into account; we do
-    not undertake that complexity here.
-    
+    """Yield mappings from a Chimera graph into a larger Chimera graph.
+
     Parameters
     ----------
         source : NetworkX Graph
-            The Chimera graph that nodes are input from
+            The Chimera graph that nodes are input from.
         target : NetworkX Graph
-            The Chimera graph that nodes are input from
+            The Chimera graph that nodes are output to.
         offset_list : iterable (tuple), optional (default None)
-            An iterable of offsets.  This can be used to reconstruct a set of
-            mappings, as the offset used to generate a single mapping is stored
+            An iterable of offsets that can be used to reconstruct a set of
+            mappings since the offset used to generate a single mapping is stored
             in the ``offset`` attribute of that mapping.
-            
+
     Yields
     ------
         mapping : function
-            A function from nodes of the source graph, to nodes of the target
-            graph.  The offset used to generate this mapping is stored in
-            ``mapping.offset`` -- these can be collected and passed into 
-            ``offset_list`` in a later session.
+            A function from the nodes of the source graph to the nodes 
+            of the target graph.  The offset used to generate this mapping 
+            is stored in ``mapping.offset``, which can be collected and passed 
+            into ``offset_list`` in a later session.
 
+    Notes
+    -----
+    A sublattice mapping is a function from the nodes of a
+    ``chimera_graph(m_s, n_s, t)`` to the nodes of a ``chimera_graph(m_t, n_t, t)``
+    with ``m_s <= m_t`` and ``n_s <= n_t``.  This sublattice mapping is used 
+    to identify subgraphs of the target Chimera graphs that are isomorphic 
+    to the source Chimera graph.  However, if the target graph is not of perfect 
+    yield, these functions do not generally produce isomorphisms; for example, 
+    if a node is missing in the target graph, it may still appear in the 
+    source graph's image.
+
+    Note that we do not produce mappings between Chimera graphs of different
+    tile parameters, and the mappings produced are not exhaustive.  The mappings
+    take the form
+
+        ``(y, x, u, k) -> (y + y_offset, x + x_offset, u, k)``
+
+    preserving the orientation and tile index of nodes. Although the notation 
+    of above Chimera coordinates is used, either or both of the target graphs 
+    may have integer or coordinate labels.
+
+    **Academic Note:** The full group of a Chimera graph's isomorphisms includes 
+    mappings which permute tile indices on a per-row and per-column basis in
+    addition to reflections and rotations of the grid of unit cells where 
+    rotations by 90 and 270 degrees induce a change in orientation.  
+    Although the full set of sublattice mappings would take those isomorphisms 
+    into account, we do not undertake that complexity here.
+    
     """
     if not (source.graph.get('family') == target.graph.get('family') == 'chimera'):
         raise ValueError("source and target graphs must be Chimera graphs constructed by dwave_networkx.chimera_graph")

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -796,7 +796,7 @@ class pegasus_coordinates(object):
         return self._pair_repack(self.iter_nice_to_linear, nlist)
 
     def graph_to_linear(self, g):
-        """Return a copy of the graph g relabeled to have linear indices"""
+        """Return a copy of the graph `g` relabeled to have linear indices."""
         labels = g.graph.get('labels')
         if labels == 'int':
             return g.copy()
@@ -823,7 +823,7 @@ class pegasus_coordinates(object):
         )
 
     def graph_to_pegasus(self, g):
-        """Return a copy of the graph g relabeled to have pegasus coordinates"""
+        """Return a copy of the graph `g` relabeled to have pegasus coordinates."""
         labels = g.graph.get('labels')
         if labels == 'int':
             nodes = self.iter_linear_to_pegasus(g)
@@ -851,7 +851,7 @@ class pegasus_coordinates(object):
         )
 
     def graph_to_nice(self, g):
-        """Return a copy of the graph p relabeled to have nice coordinates"""
+        """Return a copy of the graph `g` relabeled to have nice coordinates."""
         labels = g.graph.get('labels')
         if labels == 'int':
             nodes = self.iter_linear_to_nice(g)
@@ -1070,62 +1070,64 @@ def _pegasus_pegasus_sublattice_mapping(source_to_nice, nice_to_target, offset):
 
 
 def pegasus_sublattice_mappings(source, target, offset_list=None):
-    """Yields mappings from a Chimera or Pegasus graph into a Pegasus graph.
+    """Yield mappings from a Chimera or Pegasus graph into a Pegasus graph.
     
-    A sublattice mapping is a function from nodes of a ``pegasus_graph(m_s)`` or
-    ``chimera_graph(m_c, n_c, 4)`` to nodes of a ``pegasus_graph(m_t)`` with
-    ``m_s <= m_t`` or ``m_c <= m_t - 1`` and ``n_c <= m_t - 1``.  This is used
-    to identify subgraphs of the target Pegasus graphs which are isomorphic to
-    the source graph.  However, if the target graph is not of perfect yield,
-    these functions do not generally produce isomorphisms (for example, if a 
-    node is missing in the target graph, it may still appear in the image of the
-    source graph).
-    
-    Note that we require the tile parameter of Chimera graphs to be 4, and the
-    mappings produced are not exhaustive.  The mappings take the form
-    
-        ``(y, x, u, k) -> (t_offset, y+y_offset, x+x_offset, u, k)``
-        
-    when the source is a Chimera graph, or
-    
-        ``(t, y, x, u, k) -> ((t + t_offset)%3, y+y_offset, x+x_offset, u, k)``
-    
-    when the source is a Pegasus graph; preserving the orientation and tile
-    index of nodes.  We use the notation of Chimera coordinates and Pegasus nice 
-    coordinates above, but the mapping produced will respect the labelings of
-    the source and target graph.  Note, the notation above for Pegasus->Pegasus
-    mappings is only suggestive. See _pegasus_pegasus_sublattice_mapping for a
-    precise formula.
-    
-    Academic note: the full group of isomorphisms of a Chimera graph includes 
-    mappings which permute tile indices on a per-row and per-column basis, in
-    addition to reflections and rotations of the grid of unit tiles where 
-    rotations by 90 and 270 degrees induce a change in orientation.  The
-    isomorphisms of Pegasus graphs permit the swapping across rows and columns
-    of odd couplers, as well as a reflection about the main antidiagonal which
-    induces a change in orientation.  The full set of sublattice mappings would
-    take those isomorphisms into account; we do not undertake that complexity
-    here.
-
     Parameters
     ----------
         source : NetworkX Graph
-            The Chimera or Pegasus graph that nodes are input from
+            The Chimera or Pegasus graph that nodes are input from.
         target : NetworkX Graph
-            The Pegasus graph that nodes are output to
+            The Pegasus graph that nodes are output to.
         offset_list : iterable (tuple), optional (default None)
-            An iterable of offsets.  This can be used to reconstruct a set of
-            mappings, as the offset used to generate a single mapping is stored
+            An iterable of offsets that can be used to reconstruct a set of
+            mappings since the offset used to generate a single mapping is stored
             in the ``offset`` attribute of that mapping.
             
     Yields
     ------
         mapping : function
-            A function from nodes of the source graph, to nodes of the target
+            A function from the nodes of the source graph to the nodes of the target
             graph.  The offset used to generate this mapping is stored in
-            ``mapping.offset`` -- these can be collected and passed into 
+            ``mapping.offset``, which can be collected and passed into 
             ``offset_list`` in a later session.
+
+    Notes
+    -----
+    A sublattice mapping is a function from the nodes of a ``pegasus_graph(m_s)`` 
+    or ``chimera_graph(m_c, n_c, 4)`` to the nodes of a ``pegasus_graph(m_t)`` with
+    ``m_s <= m_t`` or ``m_c <= m_t - 1`` and ``n_c <= m_t - 1``.
+    This sublattice mapping is used to identify subgraphs of the target Pegasus 
+    graphs that are isomorphic to the source graph.  However, if the target graph 
+    is not of perfect yield, these functions do not generally produce isomorphisms; 
+    for example, if a node is missing in the target graph, it may still appear in 
+    the source graph's image.
+
+    Note that we require the tile parameter of Chimera graphs to be 4, and the
+    mappings produced are not exhaustive.  The mappings take the form
+
+        ``(y, x, u, k) -> (t_offset, y+y_offset, x+x_offset, u, k)``
         
+    when the source is a Chimera graph, or
+
+        ``(t, y, x, u, k) -> ((t + t_offset)%3, y+y_offset, x+x_offset, u, k)``
+    
+    when the source is a Pegasus graph, thus preserving the orientation and tile
+    index of nodes.  The notation of Chimera coordinates and Pegasus nice 
+    coordinates above is used, but the mapping produced will respect the labelings 
+    of the source and target graph.  Note, the notation above for 
+    Pegasus-to-Pegasus mappings is only suggestive; 
+    see `_pegasus_pegasus_sublattice_mapping` for a precise formula.
+    
+    **Academic Note:** The full group of isomorphisms of a Chimera graph includes 
+    mappings which permute tile indices on a per-row and per-column basis in
+    addition to reflections and rotations of the grid of unit tiles where 
+    rotations by 90 and 270 degrees induce a change in orientation.  The
+    isomorphisms of Pegasus graphs permit the swapping across rows and columns
+    of odd couplers as well as a reflection about the main antidiagonal which
+    induces a change in orientation. Although the full set of sublattice mappings 
+    would take those isomorphisms into account, we do not undertake that complexity
+    here.
+    
     """
     if target.graph.get('family') != 'pegasus':
         raise ValueError("source graphs must a Pegasus graph constructed by dwave_networkx.pegasus_graph")

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -354,7 +354,7 @@ class zephyr_coordinates(object):
         return self._pair_repack(self.iter_linear_to_zephyr, plist)
 
     def graph_to_linear(self, g):
-        """Return a copy of the graph g relabeled to have linear indices"""
+        """Return a copy of the graph `g` relabeled to have linear indices."""
         labels = g.graph.get('labels')
         if labels == 'int':
             return g.copy()
@@ -375,7 +375,7 @@ class zephyr_coordinates(object):
         )
 
     def graph_to_zephyr(self, g):
-        """Return a copy of the graph g relabeled to have zephyr coordinates"""
+        """Return a copy of the graph `g` relabeled to have zephyr coordinates."""
         labels = g.graph.get('labels')
         if labels == 'int':
             nodes = self.iter_linear_to_zephyr(g)
@@ -564,42 +564,7 @@ def _double_chimera_zephyr_sublattice_mapping(source_to_chimera, zephyr_to_targe
 
 
 def zephyr_sublattice_mappings(source, target, offset_list=None):
-    """Yields mappings from a Chimera or Zephyr graph into a Zephyr graph.
-
-    A sublattice mapping is a function from nodes of
-
-        * a ``zephyr_graph(m_s, t)`` to nodes of a ``zephyr_graph(m_t, t)``
-          where ``m_s <= m_t``,
-        * a ``chimera_graph(m_s, n_s, t)`` to nodes of a ``zephyr_graph(m_t, t)``
-          where ``m_s <= 2*m_t`` and ``n_s <= 2*m_t``, or
-        * a ``chimera_graph(m_s, n_s, 2*t)`` to nodes of a ``zephyr_graph(m_t, t)``
-          where ``m_s <= m_t`` and ``n_s <= m_t``, or
-
-    This is used to identify subgraphs of the target Zephyr graphs which are
-    isomorphic to the source graph. However, if the target graph is not of
-    perfect yield, these functions do not generally produce isomorphisms (for
-    example, if a node is missing in the target graph, it may still appear in
-    the image of the source graph).
-
-    Note that the tile parameter of Chimera graphs must be either the
-    same or double that of the target Zephyr graphs; if both graphs are
-    Zephyr graphs, the tile parameters must be the same. The mappings
-    produced preserve the linear ordering of tile indices; see the
-    ``_zephyr_zephyr_sublattice_mapping``,
-    ``_double_chimera_zephyr_sublattice_mapping``, and
-    ``_single_chimera_zephyr_sublattice_mapping`` internal functions for more
-    details.
-
-    Academic note: the full group of isomorphisms of a Chimera graph includes
-    mappings which permute tile indices on a per-row and per-column basis, in
-    addition to reflections and rotations of the grid of unit tiles where
-    rotations by 90 and 270 degrees induce a change in orientation.  The
-    isomorphisms of Zephyr graphs permit permutations of major tile indices on a
-    per-row and per-column basis, in addition to reflections of the grid which
-    induce inversion of orthogonal minor offsets, and rotations which induce
-    inversions of minor offsets and/or orientation. The full set of sublattice
-    mappings would take those isomorphisms into account; we do not undertake
-    that complexity here.
+    """Yield mappings from a Chimera or Zephyr graph into a Zephyr graph.
 
     Parameters
     ----------
@@ -608,18 +573,53 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
         target : NetworkX Graph
             The Zephyr graph that nodes are output to.
         offset_list : iterable (tuple), optional (default None)
-            An iterable of offsets. This can be used to reconstruct a set of
-            mappings, as the offset used to generate a single mapping is stored
+            An iterable of offsets that can be used to reconstruct a set of
+            mappings since the offset used to generate a single mapping is stored
             in the ``offset`` attribute of that mapping.
 
     Yields
     ------
         mapping : function
-            A function from nodes of the source graph, to nodes of the target
+            A function from nodes of the source graph to nodes of the target
             graph.  The offset used to generate this mapping is stored in
-            ``mapping.offset`` -- these can be collected and passed into
+            ``mapping.offset``, which can be collected and passed into
             ``offset_list`` in a later session.
 
+    Notes
+    -----
+    A sublattice mapping is a function from nodes of
+
+        * a ``zephyr_graph(m_s, t)`` to nodes of a ``zephyr_graph(m_t, t)``
+          where ``m_s <= m_t``,
+        * a ``chimera_graph(m_s, n_s, t)`` to nodes of a ``zephyr_graph(m_t, t)``
+          where ``m_s <= 2*m_t`` and ``n_s <= 2*m_t``, or
+        * a ``chimera_graph(m_s, n_s, 2*t)`` to nodes of a ``zephyr_graph(m_t, t)``
+          where ``m_s <= m_t`` and ``n_s <= m_t``.
+
+    This sublattice mapping is used to identify subgraphs of the target Zephyr graphs 
+    which are isomorphic to the source graph. However, if the target graph is not of
+    perfect yield, these functions do not generally produce isomorphisms; for
+    example, if a node is missing in the target graph, it may still appear in
+    the image of the source graph.
+
+    The tile parameter of Chimera graphs must be either the same or double 
+    that of the target Zephyr graphs; if both graphs are Zephyr graphs, 
+    the tile parameters must be the same. The mappings produced preserve 
+    the linear ordering of tile indices; see the
+    ``_zephyr_zephyr_sublattice_mapping``,
+    ``_double_chimera_zephyr_sublattice_mapping``, and
+    ``_single_chimera_zephyr_sublattice_mapping`` internal functions.
+
+    **Academic Note:** The full group of isomorphisms of a Chimera graph includes
+    mappings which permute tile indices on a per-row and per-column basis in
+    addition to reflections and rotations of the grid of unit tiles where
+    rotations by 90 and 270 degrees induce a change in orientation.  The
+    isomorphisms of Zephyr graphs permit permutations of major tile indices on a
+    per-row and per-column basis in addition to reflections of the grid that
+    induce inversion of orthogonal minor offsets and rotations that induce
+    inversions of minor offsets, orientation, or both. Although the full set 
+    of sublattice mappings would take those isomorphisms into account,
+    we do not undertake that complexity here.
     """
     if target.graph.get('family') != 'zephyr':
         raise ValueError("source graphs must a Zephyr graph constructed by dwave_networkx.zephyr_graph")


### PR DESCRIPTION
Also, edited those docstrings.

This is the fix for issue #234.