### PR TITLE
Fixed docstrings for graph relabeling and sublattice mapping functionality missing from reference documentation.

### DIFF
--- a/docs/reference/utilities.rst
+++ b/docs/reference/utilities.rst
@@ -35,21 +35,28 @@ Chimera
    :toctree: generated/
 
    chimera_coordinates.chimera_to_linear
+   chimera_coordinates.graph_to_chimera
+   chimera_coordinates.graph_to_linear
    chimera_coordinates.linear_to_chimera
+   chimera_sublattice_mappings
    find_chimera_indices
-
+   
 Pegasus
 ~~~~~~~
 
 .. autosummary::
    :toctree: generated/
 
+   pegasus_coordinates.graph_to_linear
+   pegasus_coordinates.graph_to_nice
+   pegasus_coordinates.graph_to_pegasus
    pegasus_coordinates.linear_to_nice
    pegasus_coordinates.linear_to_pegasus
    pegasus_coordinates.nice_to_linear
    pegasus_coordinates.nice_to_pegasus
    pegasus_coordinates.pegasus_to_linear
    pegasus_coordinates.pegasus_to_nice
+   pegasus_sublattice_mappings
 
 
 Zephyr

--- a/docs/reference/utilities.rst
+++ b/docs/reference/utilities.rst
@@ -67,10 +67,6 @@ Zephyr
 
    zephyr_coordinates.graph_to_linear
    zephyr_coordinates.graph_to_zephyr
-   zephyr_coordinates.iter_linear_to_zephyr
-   zephyr_coordinates.iter_linear_to_zephyr_pairs
-   zephyr_coordinates.iter_zephyr_to_linear
-   zephyr_coordinates.iter_zephyr_to_linear_pairs
    zephyr_coordinates.linear_to_zephyr
    zephyr_coordinates.zephyr_to_linear
    zephyr_sublattice_mappings

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -385,6 +385,11 @@ class chimera_coordinates(object):
         q : 4-tuple
             Chimera coordinate.
 
+        Returns
+        -------
+        r : int
+            Linear index.
+
         Examples
         --------
         >>> dnx.chimera_coordinates(16).chimera_to_linear((2, 2, 0, 0))
@@ -410,6 +415,18 @@ class chimera_coordinates(object):
         ----------
         r : int
             Linear index.
+
+        Returns
+        -------
+        i : int
+            The column of the Chimera index's unit cell associated with `r`.
+        j : int
+            The row of the Chimera index's unit cell associated with `r`.
+        u : int
+            Side of the bipartite: whether the index is even (0) or odd (1).
+            graph of the Chimera unit cell.
+        k : int
+            Index into the Chimera unit cell.
 
         Examples
         --------
@@ -497,7 +514,12 @@ class chimera_coordinates(object):
         Parameters
         ----------
         g : NetworkX Graph
-            The Chimera graph to be relabeled.        
+            The Chimera graph to be relabeled.
+
+        Returns
+        -------
+        G : NetworkX Graph
+            A Chimera graph relabeled with linear indices.
         """
         labels = g.graph.get('labels')
         if labels == 'int':
@@ -523,6 +545,12 @@ class chimera_coordinates(object):
         ----------
         g : NetworkX Graph
             The Chimera graph to be relabeled.        
+
+        Returns
+        -------
+        G : NetworkX Graph
+            An (m, n, t) Chimera graph relabeled with Chimera coordinates.
+
         """
         labels = g.graph.get('labels')
         if labels == 'int':
@@ -668,7 +696,7 @@ def chimera_sublattice_mappings(source, target, offset_list=None):
     with ``m_s <= m_t`` and ``n_s <= n_t``.  This sublattice mapping is used 
     to identify subgraphs of the target Chimera graph that is isomorphic 
     to the source Chimera graph.  However, if the target graph is not of perfect 
-    yield, this function does not generally produce isomorphisms; for example, 
+    yield,\ [#]_ this function does not generally produce isomorphisms; for example, 
     if a node is missing in the target graph, it may still appear in the 
     source graph's image.
 
@@ -681,6 +709,11 @@ def chimera_sublattice_mappings(source, target, offset_list=None):
     preserving the orientation and tile index of nodes. Although the notation 
     of above Chimera coordinates is used, either or both of the target graphs 
     may have integer or coordinate labels.
+
+    .. [#]
+        The yield is the percentage of working qubits on a QPU and the subset 
+        of available qubits is called
+        the `working graph <https://docs.dwavesys.com/docs/latest/c_gs_4.html#the-working-graph>`_.
 
     Parameters
     ----------

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -252,10 +252,10 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
 
 
 def find_chimera_indices(G):
-    """Attempt to determine the Chimera indices of the nodes in graph G.
+    """Attempts to determine the Chimera indices of the nodes in graph ``G``.
 
-    See the :func:`~chimera_graph()` function for a definition of a Chimera graph and Chimera
-    indices.
+    See the :func:`~chimera_graph()` function for a definition of a Chimera graph 
+    and Chimera indices.
 
     Parameters
     ----------
@@ -378,7 +378,7 @@ class chimera_coordinates(object):
         return self.chimera_to_linear(q)
 
     def chimera_to_linear(self, q):
-        """Convert a 4-term Chimera coordinate to a linear index.
+        """Converts a 4-term Chimera coordinate to a linear index.
 
         Parameters
         ----------
@@ -404,7 +404,7 @@ class chimera_coordinates(object):
         return self.linear_to_chimera(r)
 
     def linear_to_chimera(self, r):
-        """Convert a linear index to a 4-term Chimera coordinate.
+        """Converts a linear index to a 4-term Chimera coordinate.
 
         Parameters
         ----------
@@ -431,7 +431,7 @@ class chimera_coordinates(object):
         return self.iter_chimera_to_linear(qlist)
 
     def iter_chimera_to_linear(self, qlist):
-        """Return an iterator converting a sequence of 4-term Chimera
+        """Returns an iterator converting a sequence of 4-term Chimera
         coordinates to linear indices.
         """
         m, n, t = self.args
@@ -447,7 +447,7 @@ class chimera_coordinates(object):
         return self.iter_linear_to_chimera(rlist)
 
     def iter_linear_to_chimera(self, rlist):
-        """Return an iterator converting a sequence of linear indices to 4-term
+        """Returns an iterator converting a sequence of linear indices to 4-term
         Chimera coordinates.
         """
         m, n, t = self.args
@@ -476,7 +476,7 @@ class chimera_coordinates(object):
         return self.iter_chimera_to_linear_pairs(plist)
 
     def iter_chimera_to_linear_pairs(self, plist):
-        """Return an iterator converting a sequence of pairs of 4-term Chimera
+        """Returns an iterator converting a sequence of pairs of 4-term Chimera
         coordinates to pairs of linear indices.
         """
         return self._pair_repack(self.iter_chimera_to_linear, plist)
@@ -490,13 +490,13 @@ class chimera_coordinates(object):
         return self.iter_linear_to_chimera_pairs(plist)
 
     def iter_linear_to_chimera_pairs(self, plist):
-        """Return an iterator converting a sequence of pairs of linear indices
+        """Returns an iterator converting a sequence of pairs of linear indices
         to pairs of 4-term Chimera coordinates.
         """
         return self._pair_repack(self.iter_linear_to_chimera, plist)
 
     def graph_to_linear(self, g):
-        """Return a copy of the graph `g` relabeled to have linear indices."""
+        """Returns a copy of the graph ``g`` relabeled to have linear indices."""
         labels = g.graph.get('labels')
         if labels == 'int':
             return g.copy()
@@ -515,7 +515,7 @@ class chimera_coordinates(object):
             )
 
     def graph_to_chimera(self, g):
-        """Return a copy of the graph `g` relabeled to have Chimera coordinates."""
+        """Returns a copy of the graph ``g`` relabeled to have Chimera coordinates."""
         labels = g.graph.get('labels')
         if labels == 'int':
             return chimera_graph(
@@ -545,7 +545,7 @@ class __chimera_coordinates_cache_dict(dict):
 _chimera_coordinates_cache = __chimera_coordinates_cache_dict()
 
 def linear_to_chimera(r, m, n=None, t=None):
-    """Convert the linear index `r` into a Chimera index.
+    """Converts the linear index ``r`` into a Chimera index.
 
     Parameters
     ----------
@@ -582,14 +582,14 @@ def linear_to_chimera(r, m, n=None, t=None):
 
 
 def chimera_to_linear(i, j, u, k, m, n=None, t=None):
-    """Convert the chimera index `(i, j, u, k)` into a linear index.
+    """Converts the Chimera index ``(i, j, u, k)`` into a linear index.
 
     Parameters
     ----------
     i : int
-        The column of the Chimera index's unit cell associated with `r`.
+        The column of the Chimera index's unit cell associated with ``r``.
     j : int
-        The row of the Chimera index's unit cell associated with `r`.
+        The row of the Chimera index's unit cell associated with ``r``.
     u : int
         Whether the index is even (0) or odd (1); the side of the bipartite
         graph of the Chimera unit cell.
@@ -606,7 +606,7 @@ def chimera_to_linear(i, j, u, k, m, n=None, t=None):
     Returns
     -------
     r : int
-        The linear index node label corresponding to `(i, j, u, k)`.
+        The linear index node label corresponding to ``(i, j, u, k)``.
 
     Examples
     --------
@@ -653,7 +653,26 @@ def _chimera_sublattice_mapping(source_to_chimera, chimera_to_target, offset):
 
 
 def chimera_sublattice_mappings(source, target, offset_list=None):
-    """Yield mappings from a Chimera graph into a larger Chimera graph.
+    """Yields mappings from a Chimera graph into a larger Chimera graph.
+
+    A sublattice mapping is a function from the nodes of a
+    ``chimera_graph(m_s, n_s, t)`` to the nodes of a ``chimera_graph(m_t, n_t, t)``
+    with ``m_s <= m_t`` and ``n_s <= n_t``.  This sublattice mapping is used 
+    to identify subgraphs of the target Chimera graphs that are isomorphic 
+    to the source Chimera graph.  However, if the target graph is not of perfect 
+    yield, these functions do not generally produce isomorphisms; for example, 
+    if a node is missing in the target graph, it may still appear in the 
+    source graph's image.
+
+    Note that we do not produce mappings between Chimera graphs of different
+    tile parameters, and the mappings produced are not exhaustive.  The mappings
+    take the form
+
+        ``(y, x, u, k) -> (y + y_offset, x + x_offset, u, k)``
+
+    preserving the orientation and tile index of nodes. Although the notation 
+    of above Chimera coordinates is used, either or both of the target graphs 
+    may have integer or coordinate labels.
 
     Parameters
     ----------
@@ -676,26 +695,7 @@ def chimera_sublattice_mappings(source, target, offset_list=None):
 
     Notes
     -----
-    A sublattice mapping is a function from the nodes of a
-    ``chimera_graph(m_s, n_s, t)`` to the nodes of a ``chimera_graph(m_t, n_t, t)``
-    with ``m_s <= m_t`` and ``n_s <= n_t``.  This sublattice mapping is used 
-    to identify subgraphs of the target Chimera graphs that are isomorphic 
-    to the source Chimera graph.  However, if the target graph is not of perfect 
-    yield, these functions do not generally produce isomorphisms; for example, 
-    if a node is missing in the target graph, it may still appear in the 
-    source graph's image.
-
-    Note that we do not produce mappings between Chimera graphs of different
-    tile parameters, and the mappings produced are not exhaustive.  The mappings
-    take the form
-
-        ``(y, x, u, k) -> (y + y_offset, x + x_offset, u, k)``
-
-    preserving the orientation and tile index of nodes. Although the notation 
-    of above Chimera coordinates is used, either or both of the target graphs 
-    may have integer or coordinate labels.
-
-    **Academic Note:** The full group of a Chimera graph's isomorphisms includes 
+    The full group of a Chimera graph's isomorphisms includes 
     mappings which permute tile indices on a per-row and per-column basis in
     addition to reflections and rotations of the grid of unit cells where 
     rotations by 90 and 270 degrees induce a change in orientation.  
@@ -741,7 +741,8 @@ def chimera_sublattice_mappings(source, target, offset_list=None):
         yield _chimera_sublattice_mapping(source_to_chimera, chimera_to_target, offset)
 
 def chimera_torus(m, n=None, t=None, node_list=None, edge_list=None):
-    """Creates a defect-free Chimera lattice of size :math:`(m, n, t)` subject to periodic boundary conditions.
+    """Creates a defect-free Chimera lattice of size :math:`(m, n, t)` 
+    subject to periodic boundary conditions.
 
 
     Parameters

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -813,11 +813,11 @@ def chimera_torus(m, n=None, t=None, node_list=None, edge_list=None):
         A Chimera torus with shape (m, n, t), with Chimera coordinate node labels.
 
 
-    A Chimera torus is a generalization of the standard chimera graph
+    A Chimera torus is a generalization of the standard Chimera graph
     whereby degree-six connectivity is maintained, but the boundary
     condition is modified to enforce an additional translational-invariance 
     symmetry [RH]_. Local connectivity in the Chimera torus
-    is identical to connectivity for chimera graph nodes away from the boundary.
+    is identical to connectivity for Chimera graph nodes away from the boundary.
     The graph has :code:`V=8*m*n` nodes, and :code:`min(6, 4 + m)V//2 + 
     min(6, 4 + n)V/2` edges. With the standard :math:`K_{t, t}` Chimera tile definition,
     any tile displacement :math:`(x, y)`  modulo :math:`(m, n)`, rows and columns respectively,

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -252,7 +252,7 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
 
 
 def find_chimera_indices(G):
-    """Attempts to determine the Chimera indices of the nodes in graph G.
+    """Attempt to determine the Chimera indices of the nodes in graph G.
 
     See the :func:`~chimera_graph()` function for a definition of a Chimera graph and Chimera
     indices.
@@ -496,7 +496,7 @@ class chimera_coordinates(object):
         return self._pair_repack(self.iter_linear_to_chimera, plist)
 
     def graph_to_linear(self, g):
-        """Return a copy of the graph g relabeled to have linear indices"""
+        """Return a copy of the graph `g` relabeled to have linear indices."""
         labels = g.graph.get('labels')
         if labels == 'int':
             return g.copy()
@@ -515,7 +515,7 @@ class chimera_coordinates(object):
             )
 
     def graph_to_chimera(self, g):
-        """Return a copy of the graph g relabeled to have chimera coordinates"""
+        """Return a copy of the graph `g` relabeled to have Chimera coordinates."""
         labels = g.graph.get('labels')
         if labels == 'int':
             return chimera_graph(
@@ -545,7 +545,7 @@ class __chimera_coordinates_cache_dict(dict):
 _chimera_coordinates_cache = __chimera_coordinates_cache_dict()
 
 def linear_to_chimera(r, m, n=None, t=None):
-    """Convert the linear index `r` into a chimera index.
+    """Convert the linear index `r` into a Chimera index.
 
     Parameters
     ----------
@@ -566,7 +566,7 @@ def linear_to_chimera(r, m, n=None, t=None):
     j : int
         The row of the Chimera index's unit cell associated with `r`.
     u : int
-        Whether the index is even (0) or odd (1); the side of the bi-partite
+        Whether the index is even (0) or odd (1); the side of the bipartite
         graph of the Chimera unit cell.
     k : int
         Index into the Chimera unit cell.
@@ -591,7 +591,7 @@ def chimera_to_linear(i, j, u, k, m, n=None, t=None):
     j : int
         The row of the Chimera index's unit cell associated with `r`.
     u : int
-        Whether the index is even (0) or odd (1); the side of the bi-partite
+        Whether the index is even (0) or odd (1); the side of the bipartite
         graph of the Chimera unit cell.
     k : int
         Index into the Chimera unit cell.
@@ -626,11 +626,11 @@ def _chimera_sublattice_mapping(source_to_chimera, chimera_to_target, offset):
     Parameters
     ----------
         source_to_chimera : function
-            A function mapping a source node to a chimera-coordinate 
+            A function mapping a source node to a chimera-coordinate. 
         chimera_to_target: function
-            A function mapping a chimera coordinate to a target nodes
+            A function mapping a chimera coordinate to a target nodes.
         offset : tuple (int, int)
-            A pair of ints representing the y- and x-offset of the sublattice
+            A pair of ints representing the y- and x-offset of the sublattice.
 
     Returns
     -------
@@ -653,53 +653,55 @@ def _chimera_sublattice_mapping(source_to_chimera, chimera_to_target, offset):
 
 
 def chimera_sublattice_mappings(source, target, offset_list=None):
-    """Yields mappings from a Chimera graph into a larger Chimera graph.
-    
-    A sublattice mapping is a function from nodes of a
-    ``chimera_graph(m_s, n_s, t)`` to nodes of a ``chimera_graph(m_t, n_t, t)``
-    with ``m_s <= m_t`` and ``n_s <= n_t``.  This is used to identify subgraphs 
-    of the target Chimera graphs which are isomorphic to the source Chimera
-    graph.  However, if the target graph is not of perfect yield, these 
-    functions do not generally produce isomorphisms (for example, if a node is
-    missing in the target graph, it may still appear in the image of the source
-    graph).
-    
-    Note that we do not produce mappings between Chimera graphs of different
-    tile parameters, and the mappings produced are not exhaustive.  The mappings
-    take the form
-    
-        ``(y, x, u, k) -> (y + y_offset, x + x_offset, u, k)``
-        
-    preserving the orientation and tile index of nodes.  We use the notation of
-    Chimera coordinates above, but either or both of the target graph may have
-    integer or coordinate labels.
-    
-    Academic note: the full group of isomorphisms of a Chimera graph includes 
-    mappings which permute tile indices on a per-row and per-column basis, in
-    addition to reflections and rotations of the grid of unit cells where 
-    rotations by 90 and 270 degrees induce a change in orientation.  The full
-    set of sublattice mappings would take those isomorphisms into account; we do
-    not undertake that complexity here.
-    
+    """Yield mappings from a Chimera graph into a larger Chimera graph.
+
     Parameters
     ----------
         source : NetworkX Graph
-            The Chimera graph that nodes are input from
+            The Chimera graph that nodes are input from.
         target : NetworkX Graph
-            The Chimera graph that nodes are input from
+            The Chimera graph that nodes are output to.
         offset_list : iterable (tuple), optional (default None)
-            An iterable of offsets.  This can be used to reconstruct a set of
-            mappings, as the offset used to generate a single mapping is stored
+            An iterable of offsets that can be used to reconstruct a set of
+            mappings since the offset used to generate a single mapping is stored
             in the ``offset`` attribute of that mapping.
-            
+
     Yields
     ------
         mapping : function
-            A function from nodes of the source graph, to nodes of the target
-            graph.  The offset used to generate this mapping is stored in
-            ``mapping.offset`` -- these can be collected and passed into 
-            ``offset_list`` in a later session.
+            A function from the nodes of the source graph to the nodes 
+            of the target graph.  The offset used to generate this mapping 
+            is stored in ``mapping.offset``, which can be collected and passed 
+            into ``offset_list`` in a later session.
 
+    Notes
+    -----
+    A sublattice mapping is a function from the nodes of a
+    ``chimera_graph(m_s, n_s, t)`` to the nodes of a ``chimera_graph(m_t, n_t, t)``
+    with ``m_s <= m_t`` and ``n_s <= n_t``.  This sublattice mapping is used 
+    to identify subgraphs of the target Chimera graphs that are isomorphic 
+    to the source Chimera graph.  However, if the target graph is not of perfect 
+    yield, these functions do not generally produce isomorphisms; for example, 
+    if a node is missing in the target graph, it may still appear in the 
+    source graph's image.
+
+    Note that we do not produce mappings between Chimera graphs of different
+    tile parameters, and the mappings produced are not exhaustive.  The mappings
+    take the form
+
+        ``(y, x, u, k) -> (y + y_offset, x + x_offset, u, k)``
+
+    preserving the orientation and tile index of nodes. Although the notation 
+    of above Chimera coordinates is used, either or both of the target graphs 
+    may have integer or coordinate labels.
+
+    **Academic Note:** The full group of a Chimera graph's isomorphisms includes 
+    mappings which permute tile indices on a per-row and per-column basis in
+    addition to reflections and rotations of the grid of unit cells where 
+    rotations by 90 and 270 degrees induce a change in orientation.  
+    Although the full set of sublattice mappings would take those isomorphisms 
+    into account, we do not undertake that complexity here.
+    
     """
     if not (source.graph.get('family') == target.graph.get('family') == 'chimera'):
         raise ValueError("source and target graphs must be Chimera graphs constructed by dwave_networkx.chimera_graph")

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -418,15 +418,8 @@ class chimera_coordinates(object):
 
         Returns
         -------
-        i : int
-            The column of the Chimera index's unit cell associated with `r`.
-        j : int
-            The row of the Chimera index's unit cell associated with `r`.
-        u : int
-            Side of the bipartite: whether the index is even (0) or odd (1).
-            graph of the Chimera unit cell.
-        k : int
-            Index into the Chimera unit cell.
+        c : 4-tuple
+            Chimera coordinates as defined in :func:`~dwave_networkx.chimera_graph`.
 
         Examples
         --------
@@ -694,20 +687,20 @@ def chimera_sublattice_mappings(source, target, offset_list=None):
     A sublattice mapping is a function from the nodes of a
     ``chimera_graph(m_s, n_s, t)`` to the nodes of a ``chimera_graph(m_t, n_t, t)``
     with ``m_s <= m_t`` and ``n_s <= n_t``.  This sublattice mapping is used 
-    to identify subgraphs of the target Chimera graph that is isomorphic 
+    to identify subgraphs of the target Chimera graph that are isomorphic 
     to the source Chimera graph.  However, if the target graph is not of perfect 
     yield,\ [#]_ this function does not generally produce isomorphisms; for example, 
     if a node is missing in the target graph, it may still appear in the 
     source graph's image.
 
-    Note that we do not produce mappings between Chimera graphs of different
+    Note that this function does not produce mappings between Chimera graphs of different
     tile parameters, and the mappings produced are not exhaustive.  The mappings
     take the form
 
         ``(y, x, u, k) -> (y + y_offset, x + x_offset, u, k)``
 
     preserving the orientation and tile index of nodes. Although the notation 
-    of above Chimera coordinates is used, either or both of the target graphs 
+    of Chimera coordinates is used, either or both of the target graphs 
     may have integer or coordinate labels.
 
     .. [#]

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -549,7 +549,7 @@ class chimera_coordinates(object):
         Returns
         -------
         G : NetworkX Graph
-            An (m, n, t) Chimera graph relabeled with Chimera coordinates.
+            A Chimera graph relabeled with Chimera coordinates.
 
         """
         labels = g.graph.get('labels')

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -496,7 +496,13 @@ class chimera_coordinates(object):
         return self._pair_repack(self.iter_linear_to_chimera, plist)
 
     def graph_to_linear(self, g):
-        """Returns a copy of the graph ``g`` relabeled to have linear indices."""
+        """Returns a copy of the graph ``g`` relabeled to have linear indices.
+        
+        Parameters
+        ----------
+        g : NetworkX Graph
+            The Chimera graph to be relabeled.        
+        """
         labels = g.graph.get('labels')
         if labels == 'int':
             return g.copy()
@@ -515,7 +521,13 @@ class chimera_coordinates(object):
             )
 
     def graph_to_chimera(self, g):
-        """Returns a copy of the graph ``g`` relabeled to have Chimera coordinates."""
+        """Returns a copy of the graph ``g`` relabeled to have Chimera coordinates.
+        
+        Parameters
+        ----------
+        g : NetworkX Graph
+            The Chimera graph to be relabeled.        
+        """
         labels = g.graph.get('labels')
         if labels == 'int':
             return chimera_graph(

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -666,9 +666,9 @@ def chimera_sublattice_mappings(source, target, offset_list=None):
     A sublattice mapping is a function from the nodes of a
     ``chimera_graph(m_s, n_s, t)`` to the nodes of a ``chimera_graph(m_t, n_t, t)``
     with ``m_s <= m_t`` and ``n_s <= n_t``.  This sublattice mapping is used 
-    to identify subgraphs of the target Chimera graphs that are isomorphic 
+    to identify subgraphs of the target Chimera graph that is isomorphic 
     to the source Chimera graph.  However, if the target graph is not of perfect 
-    yield, these functions do not generally produce isomorphisms; for example, 
+    yield, this function does not generally produce isomorphisms; for example, 
     if a node is missing in the target graph, it may still appear in the 
     source graph's image.
 

--- a/dwave_networkx/generators/chimera.py
+++ b/dwave_networkx/generators/chimera.py
@@ -252,7 +252,7 @@ def chimera_graph(m, n=None, t=None, create_using=None, node_list=None, edge_lis
 
 
 def find_chimera_indices(G):
-    """Attempts to determine the Chimera indices of the nodes in graph ``G``.
+    """Determines the Chimera indices of the nodes in graph ``G``.
 
     See the :func:`~chimera_graph()` function for a definition of a Chimera graph 
     and Chimera indices.
@@ -431,8 +431,7 @@ class chimera_coordinates(object):
         return self.iter_chimera_to_linear(qlist)
 
     def iter_chimera_to_linear(self, qlist):
-        """Returns an iterator converting a sequence of 4-term Chimera
-        coordinates to linear indices.
+        """Converts a sequence of 4-term Chimera coordinates to linear indices.
         """
         m, n, t = self.args
         for (i, j, u, k) in qlist:
@@ -447,8 +446,7 @@ class chimera_coordinates(object):
         return self.iter_linear_to_chimera(rlist)
 
     def iter_linear_to_chimera(self, rlist):
-        """Returns an iterator converting a sequence of linear indices to 4-term
-        Chimera coordinates.
+        """Converts a sequence of linear indices to 4-term Chimera coordinates.
         """
         m, n, t = self.args
         for r in rlist:
@@ -476,8 +474,7 @@ class chimera_coordinates(object):
         return self.iter_chimera_to_linear_pairs(plist)
 
     def iter_chimera_to_linear_pairs(self, plist):
-        """Returns an iterator converting a sequence of pairs of 4-term Chimera
-        coordinates to pairs of linear indices.
+        """Converts pairs of 4-term Chimera coordinates to pairs of linear indices.
         """
         return self._pair_repack(self.iter_chimera_to_linear, plist)
 
@@ -490,8 +487,7 @@ class chimera_coordinates(object):
         return self.iter_linear_to_chimera_pairs(plist)
 
     def iter_linear_to_chimera_pairs(self, plist):
-        """Returns an iterator converting a sequence of pairs of linear indices
-        to pairs of 4-term Chimera coordinates.
+        """Converts pairs of linear indices to pairs of 4-term Chimera coordinates.
         """
         return self._pair_repack(self.iter_linear_to_chimera, plist)
 
@@ -578,7 +574,7 @@ def linear_to_chimera(r, m, n=None, t=None):
     j : int
         The row of the Chimera index's unit cell associated with `r`.
     u : int
-        Whether the index is even (0) or odd (1); the side of the bipartite
+        Side of the bipartite: whether the index is even (0) or odd (1).
         graph of the Chimera unit cell.
     k : int
         Index into the Chimera unit cell.
@@ -603,7 +599,7 @@ def chimera_to_linear(i, j, u, k, m, n=None, t=None):
     j : int
         The row of the Chimera index's unit cell associated with ``r``.
     u : int
-        Whether the index is even (0) or odd (1); the side of the bipartite
+        Side of the bipartite: whether the index is even (0) or odd (1).
         graph of the Chimera unit cell.
     k : int
         Index into the Chimera unit cell.
@@ -642,7 +638,7 @@ def _chimera_sublattice_mapping(source_to_chimera, chimera_to_target, offset):
         chimera_to_target: function
             A function mapping a chimera coordinate to a target nodes.
         offset : tuple (int, int)
-            A pair of ints representing the y- and x-offset of the sublattice.
+            A pair of integers representing the y- and x-offset of the sublattice.
 
     Returns
     -------
@@ -712,7 +708,7 @@ def chimera_sublattice_mappings(source, target, offset_list=None):
     addition to reflections and rotations of the grid of unit cells where 
     rotations by 90 and 270 degrees induce a change in orientation.  
     Although the full set of sublattice mappings would take those isomorphisms 
-    into account, we do not undertake that complexity here.
+    into account, this function does not handle that complex task.
     
     """
     if not (source.graph.get('family') == target.graph.get('family') == 'chimera'):

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -796,7 +796,7 @@ class pegasus_coordinates(object):
         return self._pair_repack(self.iter_nice_to_linear, nlist)
 
     def graph_to_linear(self, g):
-        """Return a copy of the graph g relabeled to have linear indices"""
+        """Return a copy of the graph `g` relabeled to have linear indices."""
         labels = g.graph.get('labels')
         if labels == 'int':
             return g.copy()
@@ -823,7 +823,7 @@ class pegasus_coordinates(object):
         )
 
     def graph_to_pegasus(self, g):
-        """Return a copy of the graph g relabeled to have pegasus coordinates"""
+        """Return a copy of the graph `g` relabeled to have pegasus coordinates."""
         labels = g.graph.get('labels')
         if labels == 'int':
             nodes = self.iter_linear_to_pegasus(g)
@@ -851,7 +851,7 @@ class pegasus_coordinates(object):
         )
 
     def graph_to_nice(self, g):
-        """Return a copy of the graph p relabeled to have nice coordinates"""
+        """Return a copy of the graph `g` relabeled to have nice coordinates."""
         labels = g.graph.get('labels')
         if labels == 'int':
             nodes = self.iter_linear_to_nice(g)
@@ -1070,62 +1070,64 @@ def _pegasus_pegasus_sublattice_mapping(source_to_nice, nice_to_target, offset):
 
 
 def pegasus_sublattice_mappings(source, target, offset_list=None):
-    """Yields mappings from a Chimera or Pegasus graph into a Pegasus graph.
+    """Yield mappings from a Chimera or Pegasus graph into a Pegasus graph.
     
-    A sublattice mapping is a function from nodes of a ``pegasus_graph(m_s)`` or
-    ``chimera_graph(m_c, n_c, 4)`` to nodes of a ``pegasus_graph(m_t)`` with
-    ``m_s <= m_t`` or ``m_c <= m_t - 1`` and ``n_c <= m_t - 1``.  This is used
-    to identify subgraphs of the target Pegasus graphs which are isomorphic to
-    the source graph.  However, if the target graph is not of perfect yield,
-    these functions do not generally produce isomorphisms (for example, if a 
-    node is missing in the target graph, it may still appear in the image of the
-    source graph).
-    
-    Note that we require the tile parameter of Chimera graphs to be 4, and the
-    mappings produced are not exhaustive.  The mappings take the form
-    
-        ``(y, x, u, k) -> (t_offset, y+y_offset, x+x_offset, u, k)``
-        
-    when the source is a Chimera graph, or
-    
-        ``(t, y, x, u, k) -> ((t + t_offset)%3, y+y_offset, x+x_offset, u, k)``
-    
-    when the source is a Pegasus graph; preserving the orientation and tile
-    index of nodes.  We use the notation of Chimera coordinates and Pegasus nice 
-    coordinates above, but the mapping produced will respect the labelings of
-    the source and target graph.  Note, the notation above for Pegasus->Pegasus
-    mappings is only suggestive. See _pegasus_pegasus_sublattice_mapping for a
-    precise formula.
-    
-    Academic note: the full group of isomorphisms of a Chimera graph includes 
-    mappings which permute tile indices on a per-row and per-column basis, in
-    addition to reflections and rotations of the grid of unit tiles where 
-    rotations by 90 and 270 degrees induce a change in orientation.  The
-    isomorphisms of Pegasus graphs permit the swapping across rows and columns
-    of odd couplers, as well as a reflection about the main antidiagonal which
-    induces a change in orientation.  The full set of sublattice mappings would
-    take those isomorphisms into account; we do not undertake that complexity
-    here.
-
     Parameters
     ----------
         source : NetworkX Graph
-            The Chimera or Pegasus graph that nodes are input from
+            The Chimera or Pegasus graph that nodes are input from.
         target : NetworkX Graph
-            The Pegasus graph that nodes are output to
+            The Pegasus graph that nodes are output to.
         offset_list : iterable (tuple), optional (default None)
-            An iterable of offsets.  This can be used to reconstruct a set of
-            mappings, as the offset used to generate a single mapping is stored
+            An iterable of offsets that can be used to reconstruct a set of
+            mappings since the offset used to generate a single mapping is stored
             in the ``offset`` attribute of that mapping.
             
     Yields
     ------
         mapping : function
-            A function from nodes of the source graph, to nodes of the target
+            A function from the nodes of the source graph to the nodes of the target
             graph.  The offset used to generate this mapping is stored in
-            ``mapping.offset`` -- these can be collected and passed into 
+            ``mapping.offset``, which can be collected and passed into 
             ``offset_list`` in a later session.
+
+    Notes
+    -----
+    A sublattice mapping is a function from the nodes of a ``pegasus_graph(m_s)`` 
+    or ``chimera_graph(m_c, n_c, 4)`` to the nodes of a ``pegasus_graph(m_t)`` with
+    ``m_s <= m_t`` or ``m_c <= m_t - 1`` and ``n_c <= m_t - 1``.
+    This sublattice mapping is used to identify subgraphs of the target Pegasus 
+    graphs that are isomorphic to the source graph.  However, if the target graph 
+    is not of perfect yield, these functions do not generally produce isomorphisms; 
+    for example, if a node is missing in the target graph, it may still appear in 
+    the source graph's image.
+
+    Note that we require the tile parameter of Chimera graphs to be 4, and the
+    mappings produced are not exhaustive.  The mappings take the form
+
+        ``(y, x, u, k) -> (t_offset, y+y_offset, x+x_offset, u, k)``
         
+    when the source is a Chimera graph, or
+
+        ``(t, y, x, u, k) -> ((t + t_offset)%3, y+y_offset, x+x_offset, u, k)``
+    
+    when the source is a Pegasus graph, thus preserving the orientation and tile
+    index of nodes.  The notation of Chimera coordinates and Pegasus nice 
+    coordinates above is used, but the mapping produced will respect the labelings 
+    of the source and target graph.  Note, the notation above for 
+    Pegasus-to-Pegasus mappings is only suggestive; 
+    see `_pegasus_pegasus_sublattice_mapping` for a precise formula.
+    
+    **Academic Note:** The full group of isomorphisms of a Chimera graph includes 
+    mappings which permute tile indices on a per-row and per-column basis in
+    addition to reflections and rotations of the grid of unit tiles where 
+    rotations by 90 and 270 degrees induce a change in orientation.  The
+    isomorphisms of Pegasus graphs permit the swapping across rows and columns
+    of odd couplers as well as a reflection about the main antidiagonal which
+    induces a change in orientation. Although the full set of sublattice mappings 
+    would take those isomorphisms into account, we do not undertake that complexity
+    here.
+    
     """
     if target.graph.get('family') != 'pegasus':
         raise ValueError("source graphs must a Pegasus graph constructed by dwave_networkx.pegasus_graph")

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -796,7 +796,13 @@ class pegasus_coordinates(object):
         return self._pair_repack(self.iter_nice_to_linear, nlist)
 
     def graph_to_linear(self, g):
-        """Returns a copy of the graph ``g`` relabeled to have linear indices."""
+        """Returns a copy of the graph ``g`` relabeled to have linear indices.
+        
+        Parameters
+        ----------
+        g : NetworkX Graph
+            The Pegasus graph to be relabeled.        
+        """
         labels = g.graph.get('labels')
         if labels == 'int':
             return g.copy()
@@ -823,7 +829,13 @@ class pegasus_coordinates(object):
         )
 
     def graph_to_pegasus(self, g):
-        """Returns a copy of the graph ``g`` relabeled to have pegasus coordinates."""
+        """Returns a copy of the graph ``g`` relabeled to have pegasus coordinates.
+        
+        Parameters
+        ----------
+        g : NetworkX Graph
+            The Pegasus graph to be relabeled.        
+        """
         labels = g.graph.get('labels')
         if labels == 'int':
             nodes = self.iter_linear_to_pegasus(g)
@@ -851,7 +863,13 @@ class pegasus_coordinates(object):
         )
 
     def graph_to_nice(self, g):
-        """Returns a copy of the graph ``g`` relabeled to have nice coordinates."""
+        """Returns a copy of the graph ``g`` relabeled to have nice coordinates.
+        
+        Parameters
+        ----------
+        g : NetworkX Graph
+            The Pegasus graph to be relabeled.        
+        """
         labels = g.graph.get('labels')
         if labels == 'int':
             nodes = self.iter_linear_to_nice(g)

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -1082,8 +1082,8 @@ def pegasus_sublattice_mappings(source, target, offset_list=None):
     or ``chimera_graph(m_c, n_c, 4)`` to the nodes of a ``pegasus_graph(m_t)`` with
     ``m_s <= m_t`` or ``m_c <= m_t - 1`` and ``n_c <= m_t - 1``.
     This sublattice mapping is used to identify subgraphs of the target Pegasus 
-    graphs that are isomorphic to the source graph.  However, if the target graph 
-    is not of perfect yield, these functions do not generally produce isomorphisms; 
+    graph that is isomorphic to the source graph.  However, if the target graph 
+    is not of perfect yield, this function does not generally produce isomorphisms; 
     for example, if a node is missing in the target graph, it may still appear in 
     the source graph's image.
 
@@ -1131,8 +1131,8 @@ def pegasus_sublattice_mappings(source, target, offset_list=None):
     isomorphisms of Pegasus graphs permit the swapping across rows and columns
     of odd couplers as well as a reflection about the main antidiagonal which
     induces a change in orientation. Although the full set of sublattice mappings 
-    would take those isomorphisms into account, we do not undertake that complexity
-    here.
+    would take those isomorphisms into account, this function does not handle 
+    that complex task.
     """
     if target.graph.get('family') != 'pegasus':
         raise ValueError("source graphs must a Pegasus graph constructed by dwave_networkx.pegasus_graph")

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -36,7 +36,7 @@ def pegasus_graph(m, create_using=None, node_list=None, edge_list=None, data=Tru
                   offset_lists=None, offsets_index=None, coordinates=False, fabric_only=True,
                   nice_coordinates=False, check_node_list=False, check_edge_list=False):
     """
-    Creates a Pegasus graph with size parameter `m`.
+    Creates a Pegasus graph with size parameter ``m``.
 
     Parameters
     ----------
@@ -108,7 +108,7 @@ def pegasus_graph(m, create_using=None, node_list=None, edge_list=None, data=Tru
     Returns
     -------
     G : NetworkX Graph
-        A Pegasus lattice for size parameter `m`.
+        A Pegasus lattice for size parameter ``m``.
 
 
     The maximum degree of this graph is 15. The number of nodes depends on multiple
@@ -560,7 +560,7 @@ class pegasus_coordinates(object):
         self.args = m, m - 1
 
     def pegasus_to_linear(self, q):
-        """Convert a 4-term Pegasus coordinate into a linear index.
+        """Converts a 4-term Pegasus coordinate into a linear index.
 
         Parameters
         ----------
@@ -577,7 +577,7 @@ class pegasus_coordinates(object):
         return ((m * u + w) * 12 + k) * m1 + z
 
     def linear_to_pegasus(self, r):
-        """Convert a linear index into a 4-term Pegasus coordinate.
+        """Converts a linear index into a 4-term Pegasus coordinate.
 
         Parameters
         ----------
@@ -598,7 +598,7 @@ class pegasus_coordinates(object):
 
     @staticmethod
     def nice_to_pegasus(n):
-        """Convert a 5-term nice coordinate into a 4-term Pegasus coordinate.
+        """Converts a 5-term nice coordinate into a 4-term Pegasus coordinate.
 
         Parameters
         ----------
@@ -627,7 +627,7 @@ class pegasus_coordinates(object):
 
     @staticmethod
     def pegasus_to_nice(p):
-        """Convert a 4-term Pegasus coordinate to a 5-term nice coordinate.
+        """Converts a 4-term Pegasus coordinate to a 5-term nice coordinate.
 
         Parameters
         ----------
@@ -657,7 +657,7 @@ class pegasus_coordinates(object):
         raise ValueError('invalid Pegasus coordinates')
 
     def linear_to_nice(self, r):
-        """Convert a linear index into a 5-term nice coordinate.
+        """Converts a linear index into a 5-term nice coordinate.
 
         Parameters
         ----------
@@ -672,7 +672,7 @@ class pegasus_coordinates(object):
         return self.pegasus_to_nice(self.linear_to_pegasus(r))
 
     def nice_to_linear(self, n):
-        """Convert a 5-term nice coordinate into a linear index.
+        """Converts a 5-term nice coordinate into a linear index.
 
         Parameters
         ----------
@@ -687,7 +687,7 @@ class pegasus_coordinates(object):
         return self.pegasus_to_linear(self.nice_to_pegasus(n))
 
     def iter_pegasus_to_linear(self, qlist):
-        """Return an iterator converting a sequence of 4-term Pegasus
+        """Returns an iterator converting a sequence of 4-term Pegasus
         coordinates to linear indices.
         """
         m, m1 = self.args
@@ -695,7 +695,7 @@ class pegasus_coordinates(object):
             yield ((m * u + w) * 12 + k) * m1 + z
 
     def iter_linear_to_pegasus(self, rlist):
-        """Return an iterator converting a sequence of linear indices to 4-term
+        """Returns an iterator converting a sequence of linear indices to 4-term
         Pegasus coordinates.
         """
         m, m1 = self.args
@@ -707,7 +707,7 @@ class pegasus_coordinates(object):
 
     @classmethod
     def iter_nice_to_pegasus(cls, nlist):
-        """Return an iterator converting a sequence of 5-term nice coordinates
+        """Returns an iterator converting a sequence of 5-term nice coordinates
         to 4-term Pegasus coordinates.
 
         Note that this method does not depend on the size of the Pegasus
@@ -718,7 +718,7 @@ class pegasus_coordinates(object):
 
     @classmethod
     def iter_pegasus_to_nice(cls, plist):
-        """Return an iterator converting a sequence of 4-term Pegasus
+        """Returns an iterator converting a sequence of 4-term Pegasus
         coordinates to 5-term nice coordinates.
 
         Note that this method does not depend on the size of the Pegasus
@@ -728,14 +728,14 @@ class pegasus_coordinates(object):
             yield cls.pegasus_to_nice(p)
 
     def iter_linear_to_nice(self, rlist):
-        """Return an iterator converting a sequence of linear indices to 5-term
+        """Returns an iterator converting a sequence of linear indices to 5-term
         nice coordinates.
         """
         for r in rlist:
             yield self.linear_to_nice(r)
 
     def iter_nice_to_linear(self, nlist):
-        """Return an iterator converting a sequence of 5-term nice coordinates
+        """Returns an iterator converting a sequence of 5-term nice coordinates
         to linear indices.
         """
         for n in nlist:
@@ -752,20 +752,20 @@ class pegasus_coordinates(object):
             yield u, v
 
     def iter_pegasus_to_linear_pairs(self, plist):
-        """Return an iterator converting a sequence of pairs of 4-term Pegasus
+        """Returns an iterator converting a sequence of pairs of 4-term Pegasus
         coordinates to pairs of linear indices.
         """
         return self._pair_repack(self.iter_pegasus_to_linear, plist)
 
     def iter_linear_to_pegasus_pairs(self, plist):
-        """Return an iterator converting a sequence of pairs of linear indices
+        """Returns an iterator converting a sequence of pairs of linear indices
         to pairs of 4-term Pegasus coordinates.
         """
         return self._pair_repack(self.iter_linear_to_pegasus, plist)
 
     @classmethod
     def iter_nice_to_pegasus_pairs(cls, nlist):
-        """Return an iterator converting a sequence of pairs of 5-term nice
+        """Returns an iterator converting a sequence of pairs of 5-term nice
         coordinates to pairs of 4-term Pegasus coordinates.
 
         Note that this method does not depend on the size of the Pegasus
@@ -775,7 +775,7 @@ class pegasus_coordinates(object):
 
     @classmethod
     def iter_pegasus_to_nice_pairs(cls, plist):
-        """Return an iterator converting a sequence of pairs of 4-term Pegasus
+        """Returns an iterator converting a sequence of pairs of 4-term Pegasus
         coordinates to pairs of 5-term nice coordinates.
 
         Note that this method does not depend on the size of the Pegasus
@@ -784,19 +784,19 @@ class pegasus_coordinates(object):
         return cls._pair_repack(cls.iter_pegasus_to_nice, plist)
 
     def iter_linear_to_nice_pairs(self, rlist):
-        """Return an iterator converting a sequence of pairs of linear indices
+        """Returns an iterator converting a sequence of pairs of linear indices
         to pairs of 5-term nice coordinates.
         """
         return self._pair_repack(self.iter_linear_to_nice, rlist)
 
     def iter_nice_to_linear_pairs(self, nlist):
-        """Return an iterator converting a sequence of pairs of 5-term nice
+        """Returns an iterator converting a sequence of pairs of 5-term nice
         coordinates to pairs of linear indices.
         """
         return self._pair_repack(self.iter_nice_to_linear, nlist)
 
     def graph_to_linear(self, g):
-        """Return a copy of the graph `g` relabeled to have linear indices."""
+        """Returns a copy of the graph ``g`` relabeled to have linear indices."""
         labels = g.graph.get('labels')
         if labels == 'int':
             return g.copy()
@@ -823,7 +823,7 @@ class pegasus_coordinates(object):
         )
 
     def graph_to_pegasus(self, g):
-        """Return a copy of the graph `g` relabeled to have pegasus coordinates."""
+        """Returns a copy of the graph ``g`` relabeled to have pegasus coordinates."""
         labels = g.graph.get('labels')
         if labels == 'int':
             nodes = self.iter_linear_to_pegasus(g)
@@ -851,7 +851,7 @@ class pegasus_coordinates(object):
         )
 
     def graph_to_nice(self, g):
-        """Return a copy of the graph `g` relabeled to have nice coordinates."""
+        """Returns a copy of the graph ``g`` relabeled to have nice coordinates."""
         labels = g.graph.get('labels')
         if labels == 'int':
             nodes = self.iter_linear_to_nice(g)
@@ -1070,29 +1070,8 @@ def _pegasus_pegasus_sublattice_mapping(source_to_nice, nice_to_target, offset):
 
 
 def pegasus_sublattice_mappings(source, target, offset_list=None):
-    """Yield mappings from a Chimera or Pegasus graph into a Pegasus graph.
+    """Yields mappings from a Chimera or Pegasus graph into a Pegasus graph.
     
-    Parameters
-    ----------
-        source : NetworkX Graph
-            The Chimera or Pegasus graph that nodes are input from.
-        target : NetworkX Graph
-            The Pegasus graph that nodes are output to.
-        offset_list : iterable (tuple), optional (default None)
-            An iterable of offsets that can be used to reconstruct a set of
-            mappings since the offset used to generate a single mapping is stored
-            in the ``offset`` attribute of that mapping.
-            
-    Yields
-    ------
-        mapping : function
-            A function from the nodes of the source graph to the nodes of the target
-            graph.  The offset used to generate this mapping is stored in
-            ``mapping.offset``, which can be collected and passed into 
-            ``offset_list`` in a later session.
-
-    Notes
-    -----
     A sublattice mapping is a function from the nodes of a ``pegasus_graph(m_s)`` 
     or ``chimera_graph(m_c, n_c, 4)`` to the nodes of a ``pegasus_graph(m_t)`` with
     ``m_s <= m_t`` or ``m_c <= m_t - 1`` and ``n_c <= m_t - 1``.
@@ -1118,7 +1097,28 @@ def pegasus_sublattice_mappings(source, target, offset_list=None):
     Pegasus-to-Pegasus mappings is only suggestive; 
     see `_pegasus_pegasus_sublattice_mapping` for a precise formula.
     
-    **Academic Note:** The full group of isomorphisms of a Chimera graph includes 
+    Parameters
+    ----------
+        source : NetworkX Graph
+            The Chimera or Pegasus graph that nodes are input from.
+        target : NetworkX Graph
+            The Pegasus graph that nodes are output to.
+        offset_list : iterable (tuple), optional (default None)
+            An iterable of offsets that can be used to reconstruct a set of
+            mappings since the offset used to generate a single mapping is stored
+            in the ``offset`` attribute of that mapping.
+            
+    Yields
+    ------
+        mapping : function
+            A function from the nodes of the source graph to the nodes of the target
+            graph.  The offset used to generate this mapping is stored in
+            ``mapping.offset``, which can be collected and passed into 
+            ``offset_list`` in a later session.
+
+    Notes
+    -----
+    The full group of isomorphisms of a Chimera graph includes 
     mappings which permute tile indices on a per-row and per-column basis in
     addition to reflections and rotations of the grid of unit tiles where 
     rotations by 90 and 270 degrees induce a change in orientation.  The
@@ -1127,7 +1127,6 @@ def pegasus_sublattice_mappings(source, target, offset_list=None):
     induces a change in orientation. Although the full set of sublattice mappings 
     would take those isomorphisms into account, we do not undertake that complexity
     here.
-    
     """
     if target.graph.get('family') != 'pegasus':
         raise ValueError("source graphs must a Pegasus graph constructed by dwave_networkx.pegasus_graph")

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -1097,12 +1097,12 @@ def pegasus_sublattice_mappings(source, target, offset_list=None):
     or ``chimera_graph(m_c, n_c, 4)`` to the nodes of a ``pegasus_graph(m_t)`` with
     ``m_s <= m_t`` or ``m_c <= m_t - 1`` and ``n_c <= m_t - 1``.
     This sublattice mapping is used to identify subgraphs of the target Pegasus 
-    graph that is isomorphic to the source graph.  However, if the target graph 
+    graph that are isomorphic to the source graph.  However, if the target graph 
     is not of perfect yield,\ [#]_ this function does not generally produce isomorphisms; 
     for example, if a node is missing in the target graph, it may still appear in 
     the source graph's image.
 
-    Note that we require the tile parameter of Chimera graphs to be 4, and the
+    Note that the function requires that the tile parameter of Chimera graphs to be 4, and the
     mappings produced are not exhaustive.  The mappings take the form
 
         ``(y, x, u, k) -> (t_offset, y+y_offset, x+x_offset, u, k)``
@@ -1113,10 +1113,10 @@ def pegasus_sublattice_mappings(source, target, offset_list=None):
     
     when the source is a Pegasus graph, thus preserving the orientation and tile
     index of nodes.  The notation of Chimera coordinates and Pegasus nice 
-    coordinates above is used, but the mapping produced respects the labelings 
+    coordinates is used, but the mapping produced respects the labelings 
     of the source and target graph.  Note, the notation above for 
     Pegasus-to-Pegasus mappings is only suggestive; 
-    see `_pegasus_pegasus_sublattice_mapping` for a precise formula.
+    see ``_pegasus_pegasus_sublattice_mapping`` in the source code for a precise formula.
 
     .. [#]
         The yield is the percentage of working qubits on a QPU and the subset 

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -687,16 +687,14 @@ class pegasus_coordinates(object):
         return self.pegasus_to_linear(self.nice_to_pegasus(n))
 
     def iter_pegasus_to_linear(self, qlist):
-        """Returns an iterator converting a sequence of 4-term Pegasus
-        coordinates to linear indices.
+        """Converts a sequence of 4-term Pegasus coordinates to linear indices.
         """
         m, m1 = self.args
         for (u, w, k, z) in qlist:
             yield ((m * u + w) * 12 + k) * m1 + z
 
     def iter_linear_to_pegasus(self, rlist):
-        """Returns an iterator converting a sequence of linear indices to 4-term
-        Pegasus coordinates.
+        """Converts a sequence of linear indices to 4-term Pegasus coordinates.
         """
         m, m1 = self.args
         for r in rlist:
@@ -707,8 +705,7 @@ class pegasus_coordinates(object):
 
     @classmethod
     def iter_nice_to_pegasus(cls, nlist):
-        """Returns an iterator converting a sequence of 5-term nice coordinates
-        to 4-term Pegasus coordinates.
+        """Converts 5-term nice coordinates to 4-term Pegasus coordinates.
 
         Note that this method does not depend on the size of the Pegasus
         lattice.
@@ -718,8 +715,7 @@ class pegasus_coordinates(object):
 
     @classmethod
     def iter_pegasus_to_nice(cls, plist):
-        """Returns an iterator converting a sequence of 4-term Pegasus
-        coordinates to 5-term nice coordinates.
+        """Converts 4-term Pegasus coordinates to 5-term nice coordinates.
 
         Note that this method does not depend on the size of the Pegasus
         lattice.
@@ -728,15 +724,13 @@ class pegasus_coordinates(object):
             yield cls.pegasus_to_nice(p)
 
     def iter_linear_to_nice(self, rlist):
-        """Returns an iterator converting a sequence of linear indices to 5-term
-        nice coordinates.
+        """Converts a sequence of linear indices to 5-term nice coordinates.
         """
         for r in rlist:
             yield self.linear_to_nice(r)
 
     def iter_nice_to_linear(self, nlist):
-        """Returns an iterator converting a sequence of 5-term nice coordinates
-        to linear indices.
+        """Converts a sequence of 5-term nice coordinates to linear indices.
         """
         for n in nlist:
             yield self.nice_to_linear(n)
@@ -752,21 +746,18 @@ class pegasus_coordinates(object):
             yield u, v
 
     def iter_pegasus_to_linear_pairs(self, plist):
-        """Returns an iterator converting a sequence of pairs of 4-term Pegasus
-        coordinates to pairs of linear indices.
+        """Converts pairs of 4-term Pegasus coordinates to pairs of linear indices.
         """
         return self._pair_repack(self.iter_pegasus_to_linear, plist)
 
     def iter_linear_to_pegasus_pairs(self, plist):
-        """Returns an iterator converting a sequence of pairs of linear indices
-        to pairs of 4-term Pegasus coordinates.
+        """Converts pairs of linear indices to pairs of 4-term Pegasus coordinates.
         """
         return self._pair_repack(self.iter_linear_to_pegasus, plist)
 
     @classmethod
     def iter_nice_to_pegasus_pairs(cls, nlist):
-        """Returns an iterator converting a sequence of pairs of 5-term nice
-        coordinates to pairs of 4-term Pegasus coordinates.
+        """Converts pairs of 5-term nice coordinates to pairs of 4-term Pegasus coordinates.
 
         Note that this method does not depend on the size of the Pegasus
         lattice.
@@ -775,8 +766,7 @@ class pegasus_coordinates(object):
 
     @classmethod
     def iter_pegasus_to_nice_pairs(cls, plist):
-        """Returns an iterator converting a sequence of pairs of 4-term Pegasus
-        coordinates to pairs of 5-term nice coordinates.
+        """Converts pairs of 4-term Pegasus coordinates to pairs of 5-term nice coordinates.
 
         Note that this method does not depend on the size of the Pegasus
         lattice.
@@ -784,14 +774,12 @@ class pegasus_coordinates(object):
         return cls._pair_repack(cls.iter_pegasus_to_nice, plist)
 
     def iter_linear_to_nice_pairs(self, rlist):
-        """Returns an iterator converting a sequence of pairs of linear indices
-        to pairs of 5-term nice coordinates.
+        """Converts pairs of linear indices to pairs of 5-term nice coordinates.
         """
         return self._pair_repack(self.iter_linear_to_nice, rlist)
 
     def iter_nice_to_linear_pairs(self, nlist):
-        """Returns an iterator converting a sequence of pairs of 5-term nice
-        coordinates to pairs of linear indices.
+        """Converts pairs of 5-term nice coordinates to pairs of linear indices.
         """
         return self._pair_repack(self.iter_nice_to_linear, nlist)
 
@@ -829,7 +817,7 @@ class pegasus_coordinates(object):
         )
 
     def graph_to_pegasus(self, g):
-        """Returns a copy of the graph ``g`` relabeled to have pegasus coordinates.
+        """Returns a copy of the graph ``g`` relabeled to have Pegasus coordinates.
         
         Parameters
         ----------
@@ -1110,7 +1098,7 @@ def pegasus_sublattice_mappings(source, target, offset_list=None):
     
     when the source is a Pegasus graph, thus preserving the orientation and tile
     index of nodes.  The notation of Chimera coordinates and Pegasus nice 
-    coordinates above is used, but the mapping produced will respect the labelings 
+    coordinates above is used, but the mapping produced respects the labelings 
     of the source and target graph.  Note, the notation above for 
     Pegasus-to-Pegasus mappings is only suggestive; 
     see `_pegasus_pegasus_sublattice_mapping` for a precise formula.

--- a/dwave_networkx/generators/pegasus.py
+++ b/dwave_networkx/generators/pegasus.py
@@ -790,6 +790,11 @@ class pegasus_coordinates(object):
         ----------
         g : NetworkX Graph
             The Pegasus graph to be relabeled.        
+
+        Returns
+        -------
+        G : NetworkX Graph
+            A Pegasus graph relabeled with linear indices.
         """
         labels = g.graph.get('labels')
         if labels == 'int':
@@ -823,6 +828,11 @@ class pegasus_coordinates(object):
         ----------
         g : NetworkX Graph
             The Pegasus graph to be relabeled.        
+
+        Returns
+        -------
+        G : NetworkX Graph
+            A Pegaus graph relabeled with 4-term Pegasus coordinates.
         """
         labels = g.graph.get('labels')
         if labels == 'int':
@@ -857,6 +867,11 @@ class pegasus_coordinates(object):
         ----------
         g : NetworkX Graph
             The Pegasus graph to be relabeled.        
+        
+        Returns
+        -------
+        G : NetworkX Graph
+            A Pegasus graph relabeled with 5-term nice coordinates.
         """
         labels = g.graph.get('labels')
         if labels == 'int':
@@ -1083,7 +1098,7 @@ def pegasus_sublattice_mappings(source, target, offset_list=None):
     ``m_s <= m_t`` or ``m_c <= m_t - 1`` and ``n_c <= m_t - 1``.
     This sublattice mapping is used to identify subgraphs of the target Pegasus 
     graph that is isomorphic to the source graph.  However, if the target graph 
-    is not of perfect yield, this function does not generally produce isomorphisms; 
+    is not of perfect yield,\ [#]_ this function does not generally produce isomorphisms; 
     for example, if a node is missing in the target graph, it may still appear in 
     the source graph's image.
 
@@ -1102,6 +1117,11 @@ def pegasus_sublattice_mappings(source, target, offset_list=None):
     of the source and target graph.  Note, the notation above for 
     Pegasus-to-Pegasus mappings is only suggestive; 
     see `_pegasus_pegasus_sublattice_mapping` for a precise formula.
+
+    .. [#]
+        The yield is the percentage of working qubits on a QPU and the subset 
+        of available qubits is called
+        the `working graph <https://docs.dwavesys.com/docs/latest/c_gs_4.html#the-working-graph>`_.
     
     Parameters
     ----------

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -274,7 +274,7 @@ class zephyr_coordinates(object):
         self.args = m, 2 * m + 1, t
 
     def zephyr_to_linear(self, q):
-        """Convert a 5-term Zephyr coordinate into a linear index.
+        """Converts a 5-term Zephyr coordinate into a linear index.
 
         Parameters
         ----------
@@ -291,7 +291,7 @@ class zephyr_coordinates(object):
         return (((u * M + w) * t + k) * 2 + j) * m + z
 
     def linear_to_zephyr(self, r):
-        """Convert a linear index into a 5-term Zephyr coordinate.
+        """Converts a linear index into a 5-term Zephyr coordinate.
 
         Parameters
         ----------
@@ -312,7 +312,7 @@ class zephyr_coordinates(object):
         return u, w, k, j, z
 
     def iter_zephyr_to_linear(self, qlist):
-        """Return an iterator converting a sequence of 5-term Zephyr
+        """Returns an iterator converting a sequence of 5-term Zephyr
         coordinates to linear indices.
         """
         m, M, t = self.args
@@ -320,7 +320,7 @@ class zephyr_coordinates(object):
             yield (((u * M + w) * t + k) * 2 + j) * m + z
 
     def iter_linear_to_zephyr(self, rlist):
-        """Return an iterator converting a sequence of linear indices to 5-term
+        """Returns an iterator converting a sequence of linear indices to 5-term
         Zephyr coordinates.
         """
         m, M, t = self.args
@@ -333,7 +333,7 @@ class zephyr_coordinates(object):
 
     @staticmethod
     def _pair_repack(f, plist):
-        """Flattens a sequence of pairs to pass through `f`, and then
+        """Flattens a sequence of pairs to pass through ``f``, and then
         re-pairs the result.
         """
         ulist = f(u for p in plist for u in p)
@@ -342,19 +342,19 @@ class zephyr_coordinates(object):
             yield u, v
 
     def iter_zephyr_to_linear_pairs(self, plist):
-        """Return an iterator converting a sequence of pairs of 5-term Zephyr
+        """Returns an iterator converting a sequence of pairs of 5-term Zephyr
         coordinates to pairs of linear indices.
         """
         return self._pair_repack(self.iter_zephyr_to_linear, plist)
 
     def iter_linear_to_zephyr_pairs(self, plist):
-        """Return an iterator converting a sequence of pairs of linear indices
+        """Returns an iterator converting a sequence of pairs of linear indices
         to pairs of 5-term Zephyr coordinates.
         """
         return self._pair_repack(self.iter_linear_to_zephyr, plist)
 
     def graph_to_linear(self, g):
-        """Return a copy of the graph `g` relabeled to have linear indices."""
+        """Returns a copy of the graph ``g`` relabeled to have linear indices."""
         labels = g.graph.get('labels')
         if labels == 'int':
             return g.copy()
@@ -375,7 +375,7 @@ class zephyr_coordinates(object):
         )
 
     def graph_to_zephyr(self, g):
-        """Return a copy of the graph `g` relabeled to have zephyr coordinates."""
+        """Returns a copy of the graph ``g`` relabeled to have zephyr coordinates."""
         labels = g.graph.get('labels')
         if labels == 'int':
             nodes = self.iter_linear_to_zephyr(g)
@@ -564,29 +564,8 @@ def _double_chimera_zephyr_sublattice_mapping(source_to_chimera, zephyr_to_targe
 
 
 def zephyr_sublattice_mappings(source, target, offset_list=None):
-    """Yield mappings from a Chimera or Zephyr graph into a Zephyr graph.
+    """Yields mappings from a Chimera or Zephyr graph into a Zephyr graph.
 
-    Parameters
-    ----------
-        source : NetworkX Graph
-            The Chimera or Zephyr graph that nodes are input from.
-        target : NetworkX Graph
-            The Zephyr graph that nodes are output to.
-        offset_list : iterable (tuple), optional (default None)
-            An iterable of offsets that can be used to reconstruct a set of
-            mappings since the offset used to generate a single mapping is stored
-            in the ``offset`` attribute of that mapping.
-
-    Yields
-    ------
-        mapping : function
-            A function from nodes of the source graph to nodes of the target
-            graph.  The offset used to generate this mapping is stored in
-            ``mapping.offset``, which can be collected and passed into
-            ``offset_list`` in a later session.
-
-    Notes
-    -----
     A sublattice mapping is a function from nodes of
 
         * a ``zephyr_graph(m_s, t)`` to nodes of a ``zephyr_graph(m_t, t)``
@@ -609,8 +588,29 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
     ``_zephyr_zephyr_sublattice_mapping``,
     ``_double_chimera_zephyr_sublattice_mapping``, and
     ``_single_chimera_zephyr_sublattice_mapping`` internal functions.
+    
+    Parameters
+    ----------
+        source : NetworkX Graph
+            The Chimera or Zephyr graph that nodes are input from.
+        target : NetworkX Graph
+            The Zephyr graph that nodes are output to.
+        offset_list : iterable (tuple), optional (default None)
+            An iterable of offsets that can be used to reconstruct a set of
+            mappings since the offset used to generate a single mapping is stored
+            in the ``offset`` attribute of that mapping.
 
-    **Academic Note:** The full group of isomorphisms of a Chimera graph includes
+    Yields
+    ------
+        mapping : function
+            A function from nodes of the source graph to nodes of the target
+            graph.  The offset used to generate this mapping is stored in
+            ``mapping.offset``, which can be collected and passed into
+            ``offset_list`` in a later session.
+
+    Notes
+    -----
+    The full group of isomorphisms of a Chimera graph includes
     mappings which permute tile indices on a per-row and per-column basis in
     addition to reflections and rotations of the grid of unit tiles where
     rotations by 90 and 270 degrees induce a change in orientation.  The

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -313,16 +313,14 @@ class zephyr_coordinates(object):
         return u, w, k, j, z
 
     def iter_zephyr_to_linear(self, qlist):
-        """Returns an iterator converting a sequence of 5-term Zephyr
-        coordinates to linear indices.
+        """Converts a sequence of 5-term Zephyr coordinates to linear indices.
         """
         m, M, t = self.args
         for (u, w, k, j, z) in qlist:
             yield (((u * M + w) * t + k) * 2 + j) * m + z
 
     def iter_linear_to_zephyr(self, rlist):
-        """Returns an iterator converting a sequence of linear indices to 5-term
-        Zephyr coordinates.
+        """Converts a sequence of linear indices to 5-term Zephyr coordinates.
         """
         m, M, t = self.args
         for r in rlist:
@@ -343,14 +341,12 @@ class zephyr_coordinates(object):
             yield u, v
 
     def iter_zephyr_to_linear_pairs(self, plist):
-        """Returns an iterator converting a sequence of pairs of 5-term Zephyr
-        coordinates to pairs of linear indices.
+        """Converts pairs of 5-term Zephyr coordinates to pairs of linear indices.
         """
         return self._pair_repack(self.iter_zephyr_to_linear, plist)
 
     def iter_linear_to_zephyr_pairs(self, plist):
-        """Returns an iterator converting a sequence of pairs of linear indices
-        to pairs of 5-term Zephyr coordinates.
+        """Converts pairs of linear indices to pairs of 5-term Zephyr coordinates.
         """
         return self._pair_repack(self.iter_linear_to_zephyr, plist)
 

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -584,9 +584,9 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
         * a ``chimera_graph(m_s, n_s, 2*t)`` to nodes of a ``zephyr_graph(m_t, t)``
           where ``m_s <= m_t`` and ``n_s <= m_t``.
 
-    This sublattice mapping is used to identify subgraphs of the target Zephyr graphs 
-    which are isomorphic to the source graph. However, if the target graph is not of
-    perfect yield, these functions do not generally produce isomorphisms; for
+    This sublattice mapping is used to identify subgraphs of the target Zephyr graph 
+    which is isomorphic to the source graph. However, if the target graph is not of
+    perfect yield, this function does not generally produce isomorphisms; for
     example, if a node is missing in the target graph, it may still appear in
     the image of the source graph.
 
@@ -628,7 +628,7 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
     induce inversion of orthogonal minor offsets and rotations that induce
     inversions of minor offsets, orientation, or both. Although the full set 
     of sublattice mappings would take those isomorphisms into account,
-    we do not undertake that complexity here.
+    this function does not handle that complex task.
     """
     if target.graph.get('family') != 'zephyr':
         raise ValueError("source graphs must a Zephyr graph constructed by dwave_networkx.zephyr_graph")

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -357,6 +357,11 @@ class zephyr_coordinates(object):
         ----------
         g : NetworkX Graph
             The Zephyr graph to be relabeled.        
+        
+        Returns
+        -------
+        G : NetworkX Graph
+            A Zephyr graph relabeled with linear indices.
         """
         labels = g.graph.get('labels')
         if labels == 'int':
@@ -378,12 +383,17 @@ class zephyr_coordinates(object):
         )
 
     def graph_to_zephyr(self, g):
-        """Returns a copy of the graph ``g`` relabeled to have zephyr coordinates.
+        """Returns a copy of the graph ``g`` relabeled to have Zephyr coordinates.
         
         Parameters
         ----------
         g : NetworkX Graph
             The Zephyr graph to be relabeled.        
+        
+        Returns
+        -------
+        G : NetworkX Graph
+            A Zephyr graph relabeled with Zephyr coordinates.
         """
         labels = g.graph.get('labels')
         if labels == 'int':
@@ -586,7 +596,7 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
 
     This sublattice mapping is used to identify subgraphs of the target Zephyr graph 
     which is isomorphic to the source graph. However, if the target graph is not of
-    perfect yield, this function does not generally produce isomorphisms; for
+    perfect yield,\ [#]_ this function does not generally produce isomorphisms; for
     example, if a node is missing in the target graph, it may still appear in
     the image of the source graph.
 
@@ -598,6 +608,11 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
     ``_double_chimera_zephyr_sublattice_mapping``, and
     ``_single_chimera_zephyr_sublattice_mapping`` internal functions.
     
+    .. [#]
+        The yield is the percentage of working qubits on a QPU and the subset 
+        of available qubits is called
+        the `working graph <https://docs.dwavesys.com/docs/latest/c_gs_4.html#the-working-graph>`_.
+        
     Parameters
     ----------
         source : NetworkX Graph

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -354,7 +354,13 @@ class zephyr_coordinates(object):
         return self._pair_repack(self.iter_linear_to_zephyr, plist)
 
     def graph_to_linear(self, g):
-        """Returns a copy of the graph ``g`` relabeled to have linear indices."""
+        """Returns a copy of the graph ``g`` relabeled to have linear indices.
+        
+        Parameters
+        ----------
+        g : NetworkX Graph
+            The Zephyr graph to be relabeled.        
+        """
         labels = g.graph.get('labels')
         if labels == 'int':
             return g.copy()
@@ -375,7 +381,13 @@ class zephyr_coordinates(object):
         )
 
     def graph_to_zephyr(self, g):
-        """Returns a copy of the graph ``g`` relabeled to have zephyr coordinates."""
+        """Returns a copy of the graph ``g`` relabeled to have zephyr coordinates.
+        
+        Parameters
+        ----------
+        g : NetworkX Graph
+            The Zephyr graph to be relabeled.        
+        """
         labels = g.graph.get('labels')
         if labels == 'int':
             nodes = self.iter_linear_to_zephyr(g)

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -354,7 +354,7 @@ class zephyr_coordinates(object):
         return self._pair_repack(self.iter_linear_to_zephyr, plist)
 
     def graph_to_linear(self, g):
-        """Return a copy of the graph g relabeled to have linear indices"""
+        """Return a copy of the graph `g` relabeled to have linear indices."""
         labels = g.graph.get('labels')
         if labels == 'int':
             return g.copy()
@@ -375,7 +375,7 @@ class zephyr_coordinates(object):
         )
 
     def graph_to_zephyr(self, g):
-        """Return a copy of the graph g relabeled to have zephyr coordinates"""
+        """Return a copy of the graph `g` relabeled to have zephyr coordinates."""
         labels = g.graph.get('labels')
         if labels == 'int':
             nodes = self.iter_linear_to_zephyr(g)
@@ -564,42 +564,7 @@ def _double_chimera_zephyr_sublattice_mapping(source_to_chimera, zephyr_to_targe
 
 
 def zephyr_sublattice_mappings(source, target, offset_list=None):
-    """Yields mappings from a Chimera or Zephyr graph into a Zephyr graph.
-
-    A sublattice mapping is a function from nodes of
-
-        * a ``zephyr_graph(m_s, t)`` to nodes of a ``zephyr_graph(m_t, t)``
-          where ``m_s <= m_t``,
-        * a ``chimera_graph(m_s, n_s, t)`` to nodes of a ``zephyr_graph(m_t, t)``
-          where ``m_s <= 2*m_t`` and ``n_s <= 2*m_t``, or
-        * a ``chimera_graph(m_s, n_s, 2*t)`` to nodes of a ``zephyr_graph(m_t, t)``
-          where ``m_s <= m_t`` and ``n_s <= m_t``, or
-
-    This is used to identify subgraphs of the target Zephyr graphs which are
-    isomorphic to the source graph. However, if the target graph is not of
-    perfect yield, these functions do not generally produce isomorphisms (for
-    example, if a node is missing in the target graph, it may still appear in
-    the image of the source graph).
-
-    Note that the tile parameter of Chimera graphs must be either the
-    same or double that of the target Zephyr graphs; if both graphs are
-    Zephyr graphs, the tile parameters must be the same. The mappings
-    produced preserve the linear ordering of tile indices; see the
-    ``_zephyr_zephyr_sublattice_mapping``,
-    ``_double_chimera_zephyr_sublattice_mapping``, and
-    ``_single_chimera_zephyr_sublattice_mapping`` internal functions for more
-    details.
-
-    Academic note: the full group of isomorphisms of a Chimera graph includes
-    mappings which permute tile indices on a per-row and per-column basis, in
-    addition to reflections and rotations of the grid of unit tiles where
-    rotations by 90 and 270 degrees induce a change in orientation.  The
-    isomorphisms of Zephyr graphs permit permutations of major tile indices on a
-    per-row and per-column basis, in addition to reflections of the grid which
-    induce inversion of orthogonal minor offsets, and rotations which induce
-    inversions of minor offsets and/or orientation. The full set of sublattice
-    mappings would take those isomorphisms into account; we do not undertake
-    that complexity here.
+    """Yield mappings from a Chimera or Zephyr graph into a Zephyr graph.
 
     Parameters
     ----------
@@ -608,18 +573,53 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
         target : NetworkX Graph
             The Zephyr graph that nodes are output to.
         offset_list : iterable (tuple), optional (default None)
-            An iterable of offsets. This can be used to reconstruct a set of
-            mappings, as the offset used to generate a single mapping is stored
+            An iterable of offsets that can be used to reconstruct a set of
+            mappings since the offset used to generate a single mapping is stored
             in the ``offset`` attribute of that mapping.
 
     Yields
     ------
         mapping : function
-            A function from nodes of the source graph, to nodes of the target
+            A function from nodes of the source graph to nodes of the target
             graph.  The offset used to generate this mapping is stored in
-            ``mapping.offset`` -- these can be collected and passed into
+            ``mapping.offset``, which can be collected and passed into
             ``offset_list`` in a later session.
 
+    Notes
+    -----
+    A sublattice mapping is a function from nodes of
+
+        * a ``zephyr_graph(m_s, t)`` to nodes of a ``zephyr_graph(m_t, t)``
+          where ``m_s <= m_t``,
+        * a ``chimera_graph(m_s, n_s, t)`` to nodes of a ``zephyr_graph(m_t, t)``
+          where ``m_s <= 2*m_t`` and ``n_s <= 2*m_t``, or
+        * a ``chimera_graph(m_s, n_s, 2*t)`` to nodes of a ``zephyr_graph(m_t, t)``
+          where ``m_s <= m_t`` and ``n_s <= m_t``.
+
+    This sublattice mapping is used to identify subgraphs of the target Zephyr graphs 
+    which are isomorphic to the source graph. However, if the target graph is not of
+    perfect yield, these functions do not generally produce isomorphisms; for
+    example, if a node is missing in the target graph, it may still appear in
+    the image of the source graph.
+
+    The tile parameter of Chimera graphs must be either the same or double 
+    that of the target Zephyr graphs; if both graphs are Zephyr graphs, 
+    the tile parameters must be the same. The mappings produced preserve 
+    the linear ordering of tile indices; see the
+    ``_zephyr_zephyr_sublattice_mapping``,
+    ``_double_chimera_zephyr_sublattice_mapping``, and
+    ``_single_chimera_zephyr_sublattice_mapping`` internal functions.
+
+    **Academic Note:** The full group of isomorphisms of a Chimera graph includes
+    mappings which permute tile indices on a per-row and per-column basis in
+    addition to reflections and rotations of the grid of unit tiles where
+    rotations by 90 and 270 degrees induce a change in orientation.  The
+    isomorphisms of Zephyr graphs permit permutations of major tile indices on a
+    per-row and per-column basis in addition to reflections of the grid that
+    induce inversion of orthogonal minor offsets and rotations that induce
+    inversions of minor offsets, orientation, or both. Although the full set 
+    of sublattice mappings would take those isomorphisms into account,
+    we do not undertake that complexity here.
     """
     if target.graph.get('family') != 'zephyr':
         raise ValueError("source graphs must a Zephyr graph constructed by dwave_networkx.zephyr_graph")

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -595,7 +595,7 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
           where ``m_s <= m_t`` and ``n_s <= m_t``.
 
     This sublattice mapping is used to identify subgraphs of the target Zephyr graph 
-    which is isomorphic to the source graph. However, if the target graph is not of
+    which are isomorphic to the source graph. However, if the target graph is not of
     perfect yield,\ [#]_ this function does not generally produce isomorphisms; for
     example, if a node is missing in the target graph, it may still appear in
     the image of the source graph.
@@ -606,7 +606,7 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
     the linear ordering of tile indices; see the
     ``_zephyr_zephyr_sublattice_mapping``,
     ``_double_chimera_zephyr_sublattice_mapping``, and
-    ``_single_chimera_zephyr_sublattice_mapping`` internal functions.
+    ``_single_chimera_zephyr_sublattice_mapping`` internal functions in the source code.
     
     .. [#]
         The yield is the percentage of working qubits on a QPU and the subset 
@@ -621,7 +621,7 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
             The Zephyr graph that nodes are output to.
         offset_list : iterable (tuple), optional (default None)
             An iterable of offsets that can be used to reconstruct a set of
-            mappings since the offset used to generate a single mapping is stored
+            mappings. The offset used to generate a single mapping is stored
             in the ``offset`` attribute of that mapping.
 
     Yields


### PR DESCRIPTION
Also, edited those docstrings.

This is the fix for issue https://github.com/dwavesystems/dwave-networkx/issues/234.

Duplicate of #237 because accidentally created PR from `main`.