### PR TITLE
Use default resource class for macos builds on CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,6 @@ jobs:
     macos:
       xcode: "14.3.0"
 
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: 1
-
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,22 +56,25 @@ jobs:
     parameters:
       python-version:
         type: string
+      xcode:
+        type: string
+        default: "14.3.0"
 
     resource_class: macos.m1.medium.gen1
 
     macos:
-      xcode: "14.3.0"
+      xcode: << parameters.xcode >>
 
     steps:
       - checkout
+
+      - restore_cache: &restore-cache-pyenv
+          key: &brew-pyenv-cache-key v1-brew-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-<< parameters.xcode >>
 
       - run:
           name: Install pyenv
           command: |
             brew install pyenv
-
-      - restore_cache: &restore-cache-pyenv
-          key: v2-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-14.3.0
 
       - run:
           name: Install python
@@ -79,8 +82,10 @@ jobs:
             pyenv install << parameters.python-version>> -s
 
       - save_cache: &save-cache-pyenv
-          key: v2-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-14.3.0
+          key: *brew-pyenv-cache-key
           paths:
+            - /Users/distiller/Library/Caches/Homebrew
+            - /usr/local/Homebrew
             - ~/.pyenv
 
       - restore_cache: *restore-cache-env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,8 @@ jobs:
       python-version:
         type: string
 
-    resource_class: macos.x86.medium.gen2   
-    
+    resource_class: macos.m1.medium.gen1
+
     macos:
       xcode: "14.3.0"
 
@@ -74,7 +74,7 @@ jobs:
             brew install pyenv
 
       - restore_cache: &restore-cache-pyenv
-          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-14.3.0
+          key: v2-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-14.3.0
 
       - run:
           name: Install python
@@ -82,7 +82,7 @@ jobs:
             pyenv install << parameters.python-version>> -s
 
       - save_cache: &save-cache-pyenv
-          key: v1-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-14.3.0
+          key: v2-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-14.3.0
           paths:
             - ~/.pyenv
 


### PR DESCRIPTION
Support for `macos.x86.medium.gen2` is soon to be dropped.

See: https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718