### PR TITLE
Fix duplicate warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,6 @@
 .. image:: https://circleci.com/gh/dwavesystems/dwave-networkx.svg?style=svg
     :target: https://circleci.com/gh/dwavesystems/dwave-networkx
 
-.. inclusion-marker-do-not-remove
-
 D-Wave NetworkX
 ===============
 

--- a/docs/bibliography.rst
+++ b/docs/bibliography.rst
@@ -1,14 +1,32 @@
 Bibliography
 ============
 
-.. [GD] V. Gogate and R. Dechter, "A Complete Anytime Algorithm for Treewidth", https://arxiv.org/abs/1207.4109
+.. [GD] 
+    V. Gogate and R. Dechter. 
+    A Complete Anytime Algorithm for Treewidth. 
+    https://arxiv.org/abs/1207.4109
 
-.. [AL] A. Lucas (2014). Ising formulations of many NP problems. Frontiers in Physics, Volume 2, Article 5.
+.. [AL] 
+    A. Lucas (2014). 
+    Ising formulations of many NP problems. 
+    Frontiers in Physics, Volume 2, Article 5.
 
-.. [DWMP] E. Dahl, "Programming the D-Wave: Map Coloring Problem", https://www.dwavesys.com/media/htfgw5bk/map-coloring-wp2.pdf
+.. [DWMP] 
+    E. Dahl. 
+    Programming the D-Wave: Map Coloring Problem. 
+    https://www.dwavesys.com/media/htfgw5bk/map-coloring-wp2.pdf
 
-.. [BBRR] K. Boothby, P. Bunyk, J. Raymond and A. Roy (2019). Next-Generation Topology of D-Wave Quantum Processors. https://arxiv.org/abs/2003.00133
+.. [BBRR] 
+    K. Boothby, P. Bunyk, J. Raymond and A. Roy (2019). 
+    Next-Generation Topology of D-Wave Quantum Processors. 
+    https://arxiv.org/abs/2003.00133
 	  
-.. [BRK] K. Boothby, J. Raymond and A. D. King (2021). Zephyr Topology of D-Wave Quantum Processors. https://dwavesys.com/media/fawfas04/14-1056a-a_zephyr_topology_of_d-wave_quantum_processors.pdf
+.. [BRK] 
+    K. Boothby, J. Raymond and A. D. King (2021). 
+    Zephyr Topology of D-Wave Quantum Processors. 
+    https://dwavesys.com/media/fawfas04/14-1056a-a_zephyr_topology_of_d-wave_quantum_processors.pdf
 	 
-.. [RH] J. Raymond, R. Stevanovic, W. Bernoudy, K. Boothby, C. C. McGeoch, A. J. Berkley, P. Farré and A. D. King (2021). Hybrid quantum annealing for larger-than-QPU lattice-structured problems. https://arxiv.org/abs/2202.03044
+.. [RH] 
+    J. Raymond, R. Stevanovic, W. Bernoudy, K. Boothby, C. C. McGeoch, A. J. Berkley, P. Farré and A. D. King (2021). 
+    Hybrid quantum annealing for larger-than-QPU lattice-structured problems. 
+    https://arxiv.org/abs/2202.03044

--- a/docs/bibliography.rst
+++ b/docs/bibliography.rst
@@ -1,13 +1,9 @@
 Bibliography
 ============
 
-.. [NX] A. A. Hagberg, D. A. Schult and P. J. Swart, “Exploring network structure, dynamics, and function using NetworkX”, in Proceedings of the 7th Python in Science Conference (SciPy2008), Gäel Varoquaux, Travis Vaught, and Jarrod Millman (Eds), (Pasadena, CA USA), pp. 11–15, Aug 2008
-
 .. [GD] V. Gogate and R. Dechter, "A Complete Anytime Algorithm for Treewidth", https://arxiv.org/abs/1207.4109
 
 .. [AL] A. Lucas (2014). Ising formulations of many NP problems. Frontiers in Physics, Volume 2, Article 5.
-
-.. [FIA] G. Facchetti, G. Iacono and C. Altafini (2011). Computing global structural balance in large-scale signed social networks. PNAS, 108, no. 52, 20953-20958
 
 .. [DWMP] E. Dahl, "Programming the D-Wave: Map Coloring Problem", https://www.dwavesys.com/media/htfgw5bk/map-coloring-wp2.pdf
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ dwave-networkx
 .. include:: README.rst
     :start-after: index-start-marker
     :end-before: index-end-marker
-    
+
 Documentation
 -------------
 
@@ -19,50 +19,50 @@ Documentation
     :Date: |today|
 
 .. note:: This documentation is for the latest version of
-   `dwave-networkx <https://github.com/dwavesystems/dwave-networkx>`_.
-   Documentation for the version currently installed by
-   `dwave-ocean-sdk <https://github.com/dwavesystems/dwave-ocean-sdk>`_
-   is here: :std:doc:`dwave-networkx <oceandocs:docs_dnx/sdk_index>`.
+    `dwave-networkx <https://github.com/dwavesystems/dwave-networkx>`_.
+    Documentation for the version currently installed by
+    `dwave-ocean-sdk <https://github.com/dwavesystems/dwave-ocean-sdk>`_
+    is here: :std:doc:`dwave-networkx <oceandocs:docs_dnx/sdk_index>`.
 
 .. sdk-start-marker
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   intro
-   reference/index
-   bibliography
+    intro
+    reference/index
+    bibliography
 
 .. sdk-end-marker
 
 .. toctree::
-   :caption: Code
-   :maxdepth: 1
+    :caption: Code
+    :maxdepth: 1
 
-   Source <https://github.com/dwavesystems/dwave-networkx>
-   installation
-   license
-
-.. toctree::
-  :caption: D-Wave's Ocean Software
-  :maxdepth: 1
-
-  Ocean Home <https://ocean.dwavesys.com/>
-  Ocean Documentation <https://docs.ocean.dwavesys.com>
-  Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>
+    Source <https://github.com/dwavesystems/dwave-networkx>
+    installation
+    license
 
 .. toctree::
-  :caption: D-Wave
-  :maxdepth: 1
+    :caption: D-Wave's Ocean Software
+    :maxdepth: 1
 
-  D-Wave <https://www.dwavesys.com>
-  Leap <https://cloud.dwavesys.com/leap/>
-  D-Wave System Documentation <https://docs.dwavesys.com/docs/latest/index.html>
+    Ocean Home <https://ocean.dwavesys.com/>
+    Ocean Documentation <https://docs.ocean.dwavesys.com>
+    Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>
+
+.. toctree::
+    :caption: D-Wave
+    :maxdepth: 1
+
+    D-Wave <https://www.dwavesys.com>
+    Leap <https://cloud.dwavesys.com/leap/>
+    D-Wave System Documentation <https://docs.dwavesys.com/docs/latest/index.html>
 
 Indices and tables
 ------------------
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-* `Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_
+*   :ref:`genindex`
+*   :ref:`modindex`
+*   :ref:`search`
+*   `Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,9 +2,14 @@
 
 .. _index_dnx:
 
-.. include:: README.rst
-  :start-after: inclusion-marker-do-not-remove
+==============
+dwave-networkx
+==============
 
+.. include:: README.rst
+    :start-after: index-start-marker
+    :end-before: index-end-marker
+    
 Documentation
 -------------
 

--- a/docs/reference/algorithms/coloring.rst
+++ b/docs/reference/algorithms/coloring.rst
@@ -13,7 +13,7 @@ The map-coloring problem is to assign a color to each region of a map
 border (represented by an edge of the graph) have different colors.
 
 .. figure:: ../../_images/Problem_MapColoring.png
-   :name: Problem_MapColoring
+   :name: Problem_MapColoringColoring
    :alt: image
    :align: center
    :scale: 70 %

--- a/docs/reference/algorithms/cover.rst
+++ b/docs/reference/algorithms/cover.rst
@@ -7,7 +7,7 @@ the edges of the graph are incident to at least one of the vertices in the
 set.
 
 .. figure:: ../../_images/Cover.png
-   :name: Cover
+   :name: CoverCover
    :alt: image
    :align: center
    :scale: 40 %

--- a/docs/reference/algorithms/elimination_ordering.rst
+++ b/docs/reference/algorithms/elimination_ordering.rst
@@ -29,10 +29,3 @@ for the subset of vertices :math:`i..n`.
    pegasus_elimination_order
    treewidth_branch_and_bound
 
-
-References
-===========
-
-.. [GD] Gogate & Dechter.
-   "A Complete Anytime Algorithm for Treewidth."
-   https://arxiv.org/abs/1207.4109

--- a/docs/reference/algorithms/packing.rst
+++ b/docs/reference/algorithms/packing.rst
@@ -6,7 +6,7 @@ An independent set is a set of a graph's vertices with no edge connecting any
 of its member pairs.
 
 .. figure:: ../../_images/Cover.png
-   :name: Cover
+   :name: CoverIndependentSet
    :alt: image
    :align: center
    :scale: 40 %

--- a/dwave_networkx/algorithms/clique.py
+++ b/dwave_networkx/algorithms/clique.py
@@ -78,8 +78,8 @@ def maximum_clique(G, sampler=None, lagrange=2.0, **sampler_args):
 
     `QUBO on Wikipedia <https://en.wikipedia.org/wiki/Quadratic_unconstrained_binary_optimization>`_
 
-    .. [AL] Lucas, A. (2014). Ising formulations of many NP problems.
-       Frontiers in Physics, Volume 2, Article 5.
+    Lucas, A. (2014). Ising formulations of many NP problems. 
+    Frontiers in Physics, Volume 2, Article 5.
     """
     if G is None:
         raise ValueError("Expected NetworkX graph!")

--- a/dwave_networkx/algorithms/coloring.py
+++ b/dwave_networkx/algorithms/coloring.py
@@ -121,12 +121,6 @@ def vertex_color(G, colors, sampler=None, **sampler_args):
         A coloring for each vertex in G such that no adjacent nodes
         share the same color. A dict of the form {node: color, ...}
 
-
-    References
-    ----------
-    .. [DWMP] Dahl, E., "Programming the D-Wave: Map Coloring Problem",
-       https://www.dwavesys.com/media/htfgw5bk/map-coloring-wp2.pdf
-
     Notes
     -----
     Samplers by their nature may not return the optimal solution. This
@@ -305,11 +299,6 @@ def min_vertex_color(G, sampler=None, chromatic_lb=None, chromatic_ub=None,
     coloring : dict
         A coloring for each vertex in G such that no adjacent nodes
         share the same color. A dict of the form {node: color, ...}
-
-    References
-    ----------
-    .. [DWMP] Dahl, E., "Programming the D-Wave: Map Coloring Problem",
-       https://www.dwavesys.com/media/htfgw5bk/map-coloring-wp2.pdf
 
     Notes
     -----

--- a/dwave_networkx/algorithms/cover.py
+++ b/dwave_networkx/algorithms/cover.py
@@ -145,8 +145,8 @@ def min_vertex_cover(G, sampler=None, lagrange=2.0, **sampler_args):
 
     https://en.wikipedia.org/wiki/Quadratic_unconstrained_binary_optimization
 
-    .. [AL] Lucas, A. (2014). Ising formulations of many NP problems.
-       Frontiers in Physics, Volume 2, Article 5.
+    Lucas, A. (2014). Ising formulations of many NP problems.
+    Frontiers in Physics, Volume 2, Article 5.
 
     """
     return min_weighted_vertex_cover(G, None, sampler, lagrange, **sampler_args)

--- a/dwave_networkx/algorithms/independent_set.py
+++ b/dwave_networkx/algorithms/independent_set.py
@@ -79,8 +79,8 @@ def maximum_weighted_independent_set(G, weight=None, sampler=None, lagrange=2.0,
 
     `QUBO on Wikipedia <https://en.wikipedia.org/wiki/Quadratic_unconstrained_binary_optimization>`_
 
-    .. [AL] Lucas, A. (2014). Ising formulations of many NP problems.
-       Frontiers in Physics, Volume 2, Article 5.
+    Lucas, A. (2014). Ising formulations of many NP problems.
+    Frontiers in Physics, Volume 2, Article 5.
 
     """
     # Get a QUBO representation of the problem
@@ -161,8 +161,8 @@ def maximum_independent_set(G, sampler=None, lagrange=2.0, **sampler_args):
 
     `QUBO on Wikipedia <https://en.wikipedia.org/wiki/Quadratic_unconstrained_binary_optimization>`_
 
-    .. [AL] Lucas, A. (2014). Ising formulations of many NP problems.
-       Frontiers in Physics, Volume 2, Article 5.
+    Lucas, A. (2014). Ising formulations of many NP problems.
+    Frontiers in Physics, Volume 2, Article 5.
 
     """
     return maximum_weighted_independent_set(G, None, sampler, lagrange, **sampler_args)

--- a/dwave_networkx/algorithms/matching.py
+++ b/dwave_networkx/algorithms/matching.py
@@ -301,8 +301,8 @@ def min_maximal_matching(G, sampler=None, **sampler_args):
 
     `QUBO on Wikipedia <https://w.wiki/r9t>`_
 
-    .. [AL] Lucas, A. (2014). Ising formulations of many NP problems.
-       Frontiers in Physics, Volume 2, Article 5.
+    Lucas, A. (2014). Ising formulations of many NP problems.
+    Frontiers in Physics, Volume 2, Article 5.
 
     """
     if not G.edges:

--- a/dwave_networkx/algorithms/social.py
+++ b/dwave_networkx/algorithms/social.py
@@ -95,9 +95,9 @@ def structural_imbalance(S, sampler=None, **sampler_args):
 
     `Ising model on Wikipedia <https://en.wikipedia.org/wiki/Ising_model>`_
 
-    .. [FIA] Facchetti, G., Iacono G., and Altafini C. (2011). Computing
-       global structural balance in large-scale signed social networks.
-       PNAS, 108, no. 52, 20953-20958
+    Facchetti, G., Iacono G., and Altafini C. (2011). 
+    Computing global structural balance in large-scale signed social networks.
+    PNAS, 108, no. 52, 20953-20958
 
     """
     h, J = structural_imbalance_ising(S)

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -157,9 +157,10 @@ def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
 
     References
     ----------
-    .. [BRK] Boothby, Raymond, King, Zephyr Topology of D-Wave Quantum
-        Processors, October 2021.
-        https://dwavesys.com/media/fawfas04/14-1056a-a_zephyr_topology_of_d-wave_quantum_processors.pdf
+    Boothby, Raymond, King. 
+    Zephyr Topology of D-Wave Quantum Processors 
+    October 2021.
+    https://dwavesys.com/media/fawfas04/14-1056a-a_zephyr_topology_of_d-wave_quantum_processors.pdf
     """
     G = nx.empty_graph(0, create_using)
     m = int(m)


### PR DESCRIPTION
Part of [sdk](https://github.com/dwavesystems/dwave-ocean-sdk/pull/300) cleanup of build warnings. 
Fixes duplicates on references, [bibliography formatting](https://docs.ocean.dwavesys.com/en/stable/docs_dnx/bibliography.html) problems, and standardizes the index.  