### PR TITLE
add topology enums and dispatch decorator

### DIFF
--- a/dwave_networkx/__future_enum.py
+++ b/dwave_networkx/__future_enum.py
@@ -1,0 +1,27 @@
+# delete after Py3.10 is dropped
+# The implementation of StrEnum and global_enum are strongly informed by
+# those found in Py3.11 but are significantly less general.
+    
+from enum import Enum as _Enum
+import sys as _sys
+
+class StrEnum(str, _Enum):
+    def __new__(cls, value):
+        member = str.__new__(cls, value)
+        member._value_ = value
+        return member
+
+    @staticmethod
+    def _generate_next_value_(name, *_):
+        #make auto() work
+        return name.lower()
+
+    def __str__(self):
+        return self._value_
+
+def global_enum(cls):
+    toplevel = cls.__module__.split('.')[-1]
+    cls.__repr__ = lambda self: f'{toplevel}.{self._name_}'
+    _sys.modules[cls.__module__].__dict__.update(cls.__members__)
+    return cls
+

--- a/dwave_networkx/__init__.py
+++ b/dwave_networkx/__init__.py
@@ -12,6 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from dwave_networkx.topology import *
+
 import dwave_networkx.generators
 from dwave_networkx.generators import *
 

--- a/dwave_networkx/drawing/__init__.py
+++ b/dwave_networkx/drawing/__init__.py
@@ -15,3 +15,10 @@
 from dwave_networkx.drawing.chimera_layout import *
 from dwave_networkx.drawing.pegasus_layout import *
 from dwave_networkx.drawing.zephyr_layout import *
+
+from dwave_networkx.drawing.qubit_layout import (
+    draw_qubit_graph_generic as draw_qubit_graph,
+    draw_embedding_generic as draw_embedding,
+    draw_yield_generic as draw_yield,
+    qubit_layout as qubit_layout
+)

--- a/dwave_networkx/drawing/chimera_layout.py
+++ b/dwave_networkx/drawing/chimera_layout.py
@@ -20,13 +20,13 @@ Tools to visualize :term:`Chimera` lattices and weighted :term:`graph` problems 
 import networkx as nx
 from networkx import draw
 
-from dwave_networkx.drawing.qubit_layout import draw_qubit_graph, draw_embedding, draw_yield
-from dwave_networkx.generators.chimera import chimera_graph, find_chimera_indices, chimera_coordinates
-
+from dwave_networkx.drawing.qubit_layout import draw_qubit_graph, draw_embedding, draw_yield, qubit_layout
+from dwave_networkx.generators.chimera import chimera_graph, find_chimera_indices, chimera_coordinates, defect_free_chimera
+from ..topology import CHIMERA
 
 __all__ = ['chimera_layout', 'draw_chimera', 'draw_chimera_embedding', 'draw_chimera_yield']
 
-
+@qubit_layout.install_dispatch(CHIMERA, pop_kwargs=('scale', 'center', 'dim'))
 def chimera_layout(G, scale=1., center=None, dim=2):
     """Positions the nodes of graph ``G`` in a Chimera layout.
 
@@ -312,16 +312,5 @@ def draw_chimera_yield(G, **kwargs):
        the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
        or ``edge_color`` parameters are ignored.
     """
-    try:
-        assert(G.graph["family"] == "chimera")
-        m = G.graph["rows"]
-        n = G.graph["columns"]
-        t = G.graph["tile"]
-        coordinates = G.graph["labels"] == "coordinate"
-    except:
-        raise ValueError("Target chimera graph needs to have columns, rows, \
-        tile, and label attributes to be able to identify faulty qubits.")
-
-    perfect_graph = chimera_graph(m,n,t, coordinates=coordinates)
-
+    perfect_graph = defect_free_chimera(G)
     draw_yield(G, chimera_layout(perfect_graph), perfect_graph, **kwargs)

--- a/dwave_networkx/drawing/pegasus_layout.py
+++ b/dwave_networkx/drawing/pegasus_layout.py
@@ -19,10 +19,10 @@ import networkx as nx
 from networkx import draw
 import numpy as np
 
-from dwave_networkx.drawing.qubit_layout import draw_qubit_graph, draw_embedding, draw_yield
-from dwave_networkx.generators.pegasus import pegasus_graph, pegasus_coordinates
+from dwave_networkx.drawing.qubit_layout import draw_qubit_graph, draw_embedding, draw_yield, qubit_layout
+from dwave_networkx.generators.pegasus import pegasus_graph, pegasus_coordinates, defect_free_pegasus
 from dwave_networkx.drawing.chimera_layout import chimera_node_placer_2d
-
+from ..topology import PEGASUS
 
 __all__ = ['pegasus_layout',
            'draw_pegasus',
@@ -30,7 +30,7 @@ __all__ = ['pegasus_layout',
            'draw_pegasus_yield',
            ]
 
-
+@qubit_layout.install_dispatch(PEGASUS, pop_kwargs = ('scale', 'center', 'dim', 'crosses'))
 def pegasus_layout(G, scale=1., center=None, dim=2, crosses=False):
     """Positions the nodes of graph ``G`` in a Pegasus topology.
 
@@ -322,18 +322,5 @@ def draw_pegasus_yield(G, **kwargs):
        the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
        or ``edge_color`` parameters are ignored.
     """
-    try:
-        assert(G.graph["family"] == "pegasus")
-        m = G.graph['columns']
-        offset_lists = (G.graph['vertical_offsets'], G.graph['horizontal_offsets'])
-        coordinates = G.graph["labels"] == "coordinate"
-        nice = G.graph["labels"] == "nice"
-        # Can't interpret fabric_only from graph attributes
-    except:
-        raise ValueError("Target pegasus graph needs to have columns, rows, \
-        tile, and label attributes to be able to identify faulty qubits.")
-
-
-    perfect_graph = pegasus_graph(m, offset_lists=offset_lists, coordinates=coordinates, nice_coordinates=nice)
-
+    perfect_graph = defect_free_pegasus(G)
     draw_yield(G, pegasus_layout(perfect_graph), perfect_graph, **kwargs)

--- a/dwave_networkx/drawing/qubit_layout.py
+++ b/dwave_networkx/drawing/qubit_layout.py
@@ -23,8 +23,20 @@ import networkx as nx
 from networkx import draw
 
 from dwave_networkx.drawing.distinguishable_colors import distinguishable_color_map
+from ..utils.decorators import topology_dispatch
 
-__all__ = ['draw_qubit_graph']
+__all__ = ['draw_qubit_graph_generic', 'draw_embedding_generic', 'draw_yield_generic', 'qubit_layout']
+
+
+@topology_dispatch
+def qubit_layout(G):
+    raise NotImplementedError(f"no dispatch defined for layouts of {G.graph.get('family')} graphs")
+
+def _get_layout_and_kwargs(G, layout, kwargs):
+    if layout is None:
+        kwargs, layout_args = qubit_layout.pop_kwargs(G, kwargs)
+        layout = qubit_layout(G, **layout_args)
+    return layout, kwargs
 
 
 def draw_qubit_graph(G, layout, linear_biases=None, quadratic_biases=None,
@@ -172,6 +184,44 @@ def draw_qubit_graph(G, layout, linear_biases=None, quadratic_biases=None,
 
     draw(G, layout, ax=ax, nodelist=nodelist, edgelist=edgelist, **kwargs)
 
+def draw_qubit_graph_generic(G, linear_biases=None, quadratic_biases=None,
+                     nodelist=None, edgelist=None, midpoint=None,
+                     **kwargs):
+    """Draws graph G with a layout computed according to its topology family.
+
+    If `linear_biases` and/or `quadratic_biases` are provided, these
+    are visualized on the plot.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        The graph to be drawn.  Must be a dwave_networkx qubit topology.
+
+    linear_biases : dict (optional, None)
+        A dict of biases associated with each node in G. Should be of
+        form {node: bias, ...}. Each bias should be numeric.
+
+    quadratic_biases : dict (optional, None)
+        A dict of biases associated with each edge in G. Should be of
+        form {edge: bias, ...}. Each bias should be numeric. Self-loop
+        edges (i.e., :math:`i=j`) are treated as linear biases.
+
+    midpoint : float (optional, default None)
+        A float that specifies where the center of the colormap should
+        be. If not provided, the colormap will default to the middle of
+        min/max values provided.
+
+    kwargs : optional keywords
+       See networkx.draw_networkx() for a description of optional keywords,
+       with the exception of the `pos` parameter which is not used by this
+       function. If `linear_biases` or `quadratic_biases` are provided,
+       any provided `node_color` or `edge_color` arguments are ignored.
+
+    """
+
+    layout, kwargs = _get_layout_and_kwargs(G, kwargs)
+    return draw_qubit_graph(G, layout, linear_biases=linear_biases, quadratic_biases=quadratic_biases,
+                     nodelist=nodelist, edgelist=edgelist, midpoint=midpoint, **kwargs)
 
 def draw_embedding(G, layout, emb, embedded_graph=None, interaction_edges=None,
                    chain_color=None, unused_color=(0.9, 0.9, 0.9, 1.0), cmap=None,
@@ -370,6 +420,70 @@ def draw_embedding(G, layout, emb, embedded_graph=None, interaction_edges=None,
          node_color=node_color, edge_color=edge_color, labels=labels,
          **kwargs)
 
+def draw_embedding_generic(G, emb, embedded_graph=None, interaction_edges=None,
+                   chain_color=None, unused_color=(0.9, 0.9, 0.9, 1.0), cmap=None,
+                   show_labels=False, overlapped_embedding=False, **kwargs):
+    """Draws an embedding onto the graph G.
+
+    If interaction_edges is not None, then only display the couplers in that
+    list.  If embedded_graph is not None, the only display the couplers between
+    chains with intended couplings according to embedded_graph.
+
+    The layout of G is computed according to its topology family.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        The graph to be drawn.  Must be a dwave_networkx qubit topology.
+
+    emb : dict
+        A dict of chains associated with each node in G.  Should be
+        of the form {node: chain, ...}.  Chains should be iterables
+        of qubit labels (qubits are nodes in G).
+
+    embedded_graph : NetworkX graph (optional, default None)
+        A graph which contains all keys of emb as nodes.  If specified,
+        edges of G will be considered interactions if and only if they
+        exist between two chains of emb if their keys are connected by
+        an edge in embedded_graph
+
+    interaction_edges : list (optional, default None)
+        A list of edges which will be used as interactions.
+
+    show_labels: boolean (optional, default False)
+        If show_labels is True, then each chain in emb is labelled with its key.
+
+    chain_color : dict (optional, default None)
+        A dict of colors associated with each key in emb.  Should be
+        of the form {node: rgba_color, ...}.  Colors should be length-4
+        tuples of floats between 0 and 1 inclusive. If chain_color is None,
+        each chain will be assigned a different color.
+
+    cmap : str or matplotlib colormap (optional, default None)
+        A matplotlib colormap for coloring of chains.  Only used if chain_color
+        is None.
+
+    unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
+        The color to use for nodes and edges of G which are not involved
+        in chains, and edges which are neither chain edges nor interactions.
+        If unused_color is None, these nodes and edges will not be shown at all.
+
+    overlapped_embedding: boolean (optional, default False)
+        If overlapped_embedding is True, then chains in emb may overlap (contain
+        the same vertices in G), and the drawing will display these overlaps as
+        concentric circles.
+
+    kwargs : optional keywords
+       See networkx.draw_networkx() for a description of optional keywords,
+       with the exception of the `pos` parameter which is not used by this
+       function. If `linear_biases` or `quadratic_biases` are provided,
+       any provided `node_color` or `edge_color` arguments are ignored.
+    """
+    layout, kwargs = _get_layout_and_kwargs(G, kwargs)
+    return draw_embedding(G, layout, emb=emb, embedded_graph=embedded_graph, interaction_edges=interaction_edges,
+                   chain_color=chain_color, unused_color=unused_color, cmap=cmap,
+                   show_labels=show_labels, overlapped_embedding=overlapped_embedding, **kwargs)
+
 
 def compute_bags(C, emb):
     # Given an overlapped embedding, compute the set of source nodes embedded at every target node.
@@ -430,7 +544,6 @@ def draw_yield(G, layout, perfect_graph, unused_color=(0.9, 0.9, 0.9, 1.0),
     perfect_graph : NetworkX graph
         The graph to be drawn with highlighted faults
 
-
     unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
         The color to use for nodes and edges of G which are not faults.
         If unused_color is None, these nodes and edges will not be shown at all.
@@ -487,3 +600,43 @@ def draw_yield(G, layout, perfect_graph, unused_color=(0.9, 0.9, 0.9, 1.0),
         draw(perfect_graph, layout, nodelist=nodelist, edgelist=edgelist,
              node_color=unused_node_color, edge_color=unused_edge_color,
              **kwargs)
+             
+def draw_yield_generic(G, linear_biases=None, unused_color=(0.9, 0.9, 0.9, 1.0),
+               fault_color=(1.0, 0.0, 0.0, 1.0), fault_shape='x',
+               fault_style='dashed', **kwargs):
+    """Draws the graph G with highlighted faults.
+    
+    The graph layout will be computed according to the topology family of G.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        The graph to be parsed for faults.  Must be a dwave_networkx qubit topology.
+
+    unused_color : tuple or color string (optional, default (0.9,0.9,0.9,1.0))
+        The color to use for nodes and edges of G which are not faults.
+        If unused_color is None, these nodes and edges will not be shown at all.
+
+    fault_color : tuple or color string (optional, default (1.0,0.0,0.0,1.0))
+        A color to represent nodes absent from the graph G. Colors should be
+        length-4 tuples of floats between 0 and 1 inclusive.
+
+    fault_shape : string, optional (default='x')
+        The shape of the fault nodes. Specification is as matplotlib.scatter
+        marker, one of 'so^>v<dph8'.
+
+    fault_style : string, optional (default='dashed')
+        Edge fault line style (solid|dashed|dotted,dashdot)
+
+    kwargs : optional keywords
+       See networkx.draw_networkx() for a description of optWional keywords,
+       with the exception of the `pos` parameter which is not used by this
+       function. If `linear_biases` or `quadratic_biases` are provided,
+       any provided `node_color` or `edge_color` arguments are ignored.
+    """
+    perfect_graph = topology_without_defects(G)
+    layout, kwargs = _get_layout_and_kwargs(perfect_graph)
+    return draw_qubit_graph(G, layout, unused_color=unused_color,
+               fault_color=fault_color, fault_shape=fault_shape,
+               fault_style=fault_style, **kwargs)
+

--- a/dwave_networkx/drawing/zephyr_layout.py
+++ b/dwave_networkx/drawing/zephyr_layout.py
@@ -20,9 +20,9 @@ import networkx as nx
 from networkx import draw
 import numpy as np
 
-from dwave_networkx.drawing.qubit_layout import draw_qubit_graph, draw_embedding, draw_yield
-from dwave_networkx.generators.zephyr import zephyr_graph, zephyr_coordinates
-
+from dwave_networkx.drawing.qubit_layout import draw_qubit_graph, draw_embedding, draw_yield, qubit_layout
+from dwave_networkx.generators.zephyr import zephyr_graph, zephyr_coordinates, defect_free_zephyr
+from ..topology import ZEPHYR
 
 __all__ = ['zephyr_layout',
            'draw_zephyr',
@@ -30,7 +30,7 @@ __all__ = ['zephyr_layout',
            'draw_zephyr_yield',
            ]
 
-
+@qubit_layout.install_dispatch(ZEPHYR, pop_kwargs=('scale', 'center', 'dim'))
 def zephyr_layout(G, scale=1., center=None, dim=2):
     """Positions the nodes of graph ``G`` in a Zephyr topology.
 
@@ -282,16 +282,5 @@ def draw_zephyr_yield(G, **kwargs):
        the :func:`~networkx.drawing.nx_pylab.draw_networkx` ``node_color``
        or ``edge_color`` parameters are ignored.
     """
-    try:
-        assert(G.graph["family"] == "zephyr")
-        m = G.graph['columns']
-        t = G.graph['tile']
-        coordinates = G.graph["labels"] == "coordinate"
-    except:
-        raise ValueError("Target zephyr graph needs to have columns, rows, \
-        tile, and label attributes to be able to identify faulty qubits.")
-
-
-    perfect_graph = zephyr_graph(m, t, coordinates=coordinates)
-
+    perfect_graph = defect_free_zephyr(G)
     draw_yield(G, zephyr_layout(perfect_graph), perfect_graph, **kwargs)

--- a/dwave_networkx/generators/common.py
+++ b/dwave_networkx/generators/common.py
@@ -1,3 +1,18 @@
+# Copyright 2022 D-Wave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..utils.decorators import topology_dispatch
 
 def _add_compatible_edges(G, edge_list):
     # Check edge_list defines a subgraph of G and create subgraph.
@@ -27,3 +42,9 @@ def _add_compatible_terms(G, node_list, edge_list):
     #Check node deletion hasn't caused edge deletion:
     if edge_list is not None and len(edge_list) != G.number_of_edges():
         raise ValueError('The edge_list contains nodes absent from the node_list')
+
+@topology_dispatch
+def defect_free(G):
+    """Construct a defect-free topology based on the properties of G."""
+    raise NotImplementedError(f"no defect-free generator defined for {G.graph.get('family')} graphs")
+

--- a/dwave_networkx/generators/zephyr.py
+++ b/dwave_networkx/generators/zephyr.py
@@ -25,7 +25,9 @@ from dwave_networkx.exceptions import DWaveNetworkXException
 
 from .chimera import _chimera_coordinates_cache
 
-from .common import _add_compatible_edges, _add_compatible_nodes, _add_compatible_terms
+from .common import _add_compatible_edges, _add_compatible_nodes, _add_compatible_terms, defect_free
+from ..topology import CHIMERA, ZEPHYR
+
 
 __all__ = ['zephyr_graph',
            'zephyr_coordinates',
@@ -180,7 +182,7 @@ def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
         def label(u, w, k, j, z):
             return (((u * M + w) * t + k) * 2 + j) * m + z
 
-    construction = (("family", "zephyr"), ("rows", m), ("columns", m),
+    construction = (("family", ZEPHYR), ("rows", m), ("columns", m),
                     ("tile", t), ("data", data), ("labels", labels))
 
     G.graph.update(construction)
@@ -252,6 +254,18 @@ def zephyr_graph(m, t=4, create_using=None, node_list=None, edge_list=None,
                             v += 1
 
     return G
+
+
+@defect_free.install_dispatch(ZEPHYR)
+def defect_free_zephyr(G):
+    """Construct a defect-free Zephyr graph based on the properties of G."""
+    attrib = G.graph
+    family = attrib.get('family')
+    if family != ZEPHYR:
+        raise ValueError("G must be constructed by dwave_networkx.zephyr_graph")
+    args = attrib['rows'], attrib['tile']
+    kwargs = {'coordinates': attrib['labels'] == 'coordinate'}
+    return zephyr_graph(*args, **kwargs)
 
 
 # Developer note: we could implement a function that creates the iter_*_to_* and
@@ -646,7 +660,7 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
     of sublattice mappings would take those isomorphisms into account,
     this function does not handle that complex task.
     """
-    if target.graph.get('family') != 'zephyr':
+    if target.graph.get('family') != ZEPHYR:
         raise ValueError("source graphs must a Zephyr graph constructed by dwave_networkx.zephyr_graph")
 
     m_t = target.graph['rows']
@@ -661,7 +675,7 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
         raise ValueError(f"Zephyr node labeling {labels_t} not recognized")
 
     labels_s = source.graph['labels']
-    if source.graph.get('family') == 'chimera':
+    if source.graph.get('family') == CHIMERA:
         t_t = source.graph['tile']
         m_s = source.graph['rows']
         n_s = source.graph['columns']
@@ -691,7 +705,7 @@ def zephyr_sublattice_mappings(source, target, offset_list=None):
         else:
             raise ValueError(f"Chimera node labeling {labels_s} not recognized")
 
-    elif source.graph.get('family') == 'zephyr':
+    elif source.graph.get('family') == ZEPHYR:
         m_s = source.graph['rows']
         if offset_list is None:
             mrange = range((2*m_t+1) - (2*m_s+1) + 1)

--- a/dwave_networkx/topology.py
+++ b/dwave_networkx/topology.py
@@ -1,0 +1,13 @@
+try:
+    from enum import StrEnum as _StrEnum, global_enum as _global_enum, auto as _auto
+except ImportError:
+    from enum import auto as _auto
+    from .__future_enum import StrEnum as _StrEnum, global_enum as _global_enum
+
+@_global_enum
+class Topology(_StrEnum):
+    CHIMERA = _auto()
+    PEGASUS = _auto()
+    ZEPHYR = _auto()
+    
+__all__ = ['Topology', *Topology.__members__]


### PR DESCRIPTION
This is a preliminary patch to address #210 -- we add a `topology` enum to `dnx.topology`, and a decorator `topology_dispatch`. 

The topology enum is pretty simple, except that I want the machinery of py3.11's StrEnum (that is, `CHIMERA == 'chimera'`), so I fair-use'd barebones implementations of StrEnum and global_enum from the CPython3.11 library.

The `topology_dispatch` decorator can be used to define a generic function in one file, and then in other files, define specializations based on the topology family.  For example, I've added a `defect_free` generic function in `dnx.generators.common` and then added specializations for each of `CHIMERA`, `PEGASUS`, `ZEPHYR`.  Thus, to get a defect-free version of any qubit topology, one can simply call `dnx.generators.common.defect_free(G)`.

```python
#############
# common.py
#
@topology_dispatch
def defect_free(G):
    """Construct a defect-free topology based on the properties of G."""
    raise NotImplementedError(f"no defect-free generator defined for {G.graph.get('family')} graphs")


#############
# chimera.py
#
from ..topology import CHIMERA
from .common import defect_free

@defect_free.install_dispatch(CHIMERA)
def defect_free_chimera(G):
    """Construct a defect-free Chimera graph based on the properties of G."""
    attrib = G.graph
    family = attrib.get('family')
    if family != CHIMERA:
        raise ValueError("G must be constructed by dwave_networkx.chimera_graph")
    args = attrib['rows'], attrib['columns'], attrib['tile']
    kwargs = {'coordinates': attrib['labels'] == 'coordinate'}
    return chimera_graph(*args, **kwargs)
```